### PR TITLE
fix stream decoding to handle multi-byte characters

### DIFF
--- a/src/lib/utils/json.ts
+++ b/src/lib/utils/json.ts
@@ -29,6 +29,8 @@ export async function readStreamToText(stream: ReadableStream<Uint8Array>): Prom
     if (done) break;
     all += dec.decode(value, { stream: true });
   }
+  // Flush decoder's internal buffer to avoid truncating multi-byte chars
+  all += dec.decode();
   // Try full JSON first
   const j = safeJSON<any>(all, null as any);
   if (j?.choices?.[0]?.message?.content) return j.choices[0].message.content as string;


### PR DESCRIPTION
## Summary
- ensure `readStreamToText` flushes TextDecoder to avoid dropping bytes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Can't resolve 'zod')*


------
https://chatgpt.com/codex/tasks/task_e_689bf9d1ae348321b7a186c70a6dee49