### PR TITLE
feat: dynamic language and direction selection

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,9 +11,9 @@
   --gap:12px;
 }
 *{box-sizing:border-box}
-html{direction:rtl}
 body{
-  margin:0; font-family: system-ui, -apple-system, Segoe UI, Arial, sans-serif;
+  margin:0;
+  font-family: "STIX Two Math", "Noto Sans", "Arial Unicode MS", system-ui, -apple-system, Segoe UI, Arial, sans-serif;
   background: radial-gradient(1200px 600px at 70% -10%, #1b2030 0%, var(--bg) 55%);
   color:var(--text);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,14 @@
-import "./globals.css";
+"use client";
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+import "./globals.css";
+import { LangDirProvider, useLangDir } from "../lib/lang";
+
+function LayoutInner({ children }: { children: React.ReactNode }) {
+  const { lang, dir } = useLangDir();
   return (
-    <html lang="ar" dir="rtl">
+    <html lang={lang} dir={dir}>
       <head>
+        <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Qaadi Live</title>
         <meta name="theme-color" content="#111111" />
@@ -26,5 +31,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="wrapper">{children}</div>
       </body>
     </html>
+  );
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <LangDirProvider>
+      <LayoutInner>{children}</LayoutInner>
+    </LangDirProvider>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
+import { useLangDir } from "../lib/lang";
 
 type Template = "WideAR" | "ReVTeX" | "InquiryTR";
 type ModelSel = "openai" | "deepseek" | "auto";
@@ -12,6 +13,19 @@ export default function Page() {
   const [model, setModel] = useState<ModelSel>("auto");
   const [maxTokens, setMaxTokens] = useState(2048);
   const [text, setText] = useState("");
+
+  const { lang, dir, setLang, setDir } = useLangDir();
+  const languages = [
+    { code: "ar", name: "العربية", dir: "rtl" },
+    { code: "en", name: "English", dir: "ltr" },
+    { code: "tr", name: "Türkçe", dir: "ltr" }
+  ];
+
+  useEffect(() => {
+    if (template === "ReVTeX") { setLang("en"); setDir("ltr"); }
+    else if (template === "WideAR") { setLang("ar"); setDir("rtl"); }
+    else if (template === "InquiryTR") { setLang("tr"); setDir("ltr"); }
+  }, [template, setLang, setDir]);
 
   const [out, setOut] = useState<string>("");
   const [busy, setBusy] = useState(false);
@@ -140,15 +154,42 @@ export default function Page() {
             <option value="deepseek">deepseek</option>
           </select>
         </div>
-        <div>
-          <label>Template</label>
-          <select value={template} onChange={e=>setTemplate(e.target.value as Template)}>
-            <option value="ReVTeX">ReVTeX (EN)</option>
-            <option value="WideAR">Wide/AR (AR)</option>
-            <option value="InquiryTR">Inquiry (TR)</option>
-          </select>
-        </div>
+      <div>
+        <label>Template</label>
+        <select value={template} onChange={e=>setTemplate(e.target.value as Template)}>
+          <option value="ReVTeX">ReVTeX (EN)</option>
+          <option value="WideAR">Wide/AR (AR)</option>
+          <option value="InquiryTR">Inquiry (TR)</option>
+        </select>
       </div>
+    </div>
+
+    <div className="card grid grid-2" style={{marginBottom:12}}>
+      <div>
+        <label>Language</label>
+        <select
+          value={lang}
+          onChange={e => {
+            const l = languages.find(x => x.code === e.target.value)!;
+            setLang(l.code);
+            setDir(l.dir as "ltr" | "rtl");
+          }}
+        >
+          {languages.map(l => (
+            <option key={l.code} value={l.code}>
+              {l.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label>Direction</label>
+        <select value={dir} onChange={e => setDir(e.target.value as "ltr" | "rtl")}>
+          <option value="ltr">ltr</option>
+          <option value="rtl">rtl</option>
+        </select>
+      </div>
+    </div>
 
       <div className="card" style={{marginBottom:12}}>
         <label>النص</label>

--- a/src/lib/lang.tsx
+++ b/src/lib/lang.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+
+type LangDirContextType = {
+  lang: string;
+  dir: "ltr" | "rtl";
+  setLang: (lang: string) => void;
+  setDir: (dir: "ltr" | "rtl") => void;
+};
+
+const LangDirContext = createContext<LangDirContextType>({
+  lang: "ar",
+  dir: "rtl",
+  setLang: () => {},
+  setDir: () => {}
+});
+
+export function LangDirProvider({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState("ar");
+  const [dir, setDir] = useState<"ltr" | "rtl">("rtl");
+  return (
+    <LangDirContext.Provider value={{ lang, dir, setLang, setDir }}>
+      {children}
+    </LangDirContext.Provider>
+  );
+}
+
+export function useLangDir() {
+  return useContext(LangDirContext);
+}
+


### PR DESCRIPTION
## Summary
- add language/direction context and provider
- update layout to use context-driven `<html>` attributes and UTF-8 metadata
- expose language and direction selectors on main page and load math-friendly fonts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Module not found: Can't resolve 'zod')*

------
https://chatgpt.com/codex/tasks/task_e_689c003319b08321ba0f3204adf098e5