### PR TITLE
Add quickstart page with default generation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body>
-        <div className="wrapper">{children}</div>
+        <div className="wrapper">
+          <header style={{ marginBottom: 16 }}>
+            <nav style={{ display: "flex", gap: 12 }}>
+              <a href="/">الرئيسية</a>
+              <a href="/quickstart">Quickstart</a>
+            </nav>
+          </header>
+          {children}
+        </div>
       </body>
     </html>
   );

--- a/src/app/quickstart/page.tsx
+++ b/src/app/quickstart/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { useState } from "react";
+import TargetSelect from "../../components/TargetSelect";
+import LanguageSelect from "../../components/LanguageSelect";
+import GenerateButton from "../../components/GenerateButton";
+
+export default function QuickstartPage() {
+  const [target, setTarget] = useState("general");
+  const [language, setLanguage] = useState("ar");
+  const [text, setText] = useState("مثال سريع للنص");
+  const [out, setOut] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function handleGenerate() {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          template: "ReVTeX",
+          model: "auto",
+          max_tokens: 512,
+          text
+        })
+      });
+      const j = await res.json();
+      if (!res.ok) throw new Error(j?.error || "generate_failed");
+      setOut(j?.text || "");
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <h1 className="h1">Quickstart</h1>
+      <div className="card grid grid-2" style={{ marginBottom: 12 }}>
+        <TargetSelect value={target} onChange={setTarget} />
+        <LanguageSelect value={language} onChange={setLanguage} />
+      </div>
+      <div className="card" style={{ marginBottom: 12 }}>
+        <label>النص</label>
+        <textarea rows={6} value={text} onChange={e => setText(e.target.value)} />
+      </div>
+      <div className="card" style={{ marginBottom: 12 }}>
+        <div className="actions">
+          <GenerateButton onClick={handleGenerate} disabled={busy} />
+        </div>
+      </div>
+      <div className="card">
+        <label>Output</label>
+        <textarea className="output" value={out} readOnly />
+      </div>
+    </>
+  );
+}

--- a/src/components/GenerateButton.tsx
+++ b/src/components/GenerateButton.tsx
@@ -1,0 +1,15 @@
+"use client";
+import React from "react";
+
+interface Props {
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export default function GenerateButton({ onClick, disabled }: Props) {
+  return (
+    <button className="btn btn-primary" onClick={onClick} disabled={disabled}>
+      توليد
+    </button>
+  );
+}

--- a/src/components/LanguageSelect.tsx
+++ b/src/components/LanguageSelect.tsx
@@ -1,0 +1,20 @@
+"use client";
+import React from "react";
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+export default function LanguageSelect({ value, onChange }: Props) {
+  return (
+    <div>
+      <label>Language</label>
+      <select value={value} onChange={e => onChange(e.target.value)}>
+        <option value="ar">Arabic</option>
+        <option value="en">English</option>
+        <option value="tr">Turkish</option>
+      </select>
+    </div>
+  );
+}

--- a/src/components/TargetSelect.tsx
+++ b/src/components/TargetSelect.tsx
@@ -1,0 +1,20 @@
+"use client";
+import React from "react";
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+export default function TargetSelect({ value, onChange }: Props) {
+  return (
+    <div>
+      <label>Target</label>
+      <select value={value} onChange={e => onChange(e.target.value)}>
+        <option value="general">General</option>
+        <option value="science">Science</option>
+        <option value="law">Law</option>
+      </select>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `/quickstart` page using basic selectors and one-step generation
- create reusable `TargetSelect`, `LanguageSelect`, and `GenerateButton` components
- expose quickstart link in the header navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Module not found: Can't resolve 'zod')

------
https://chatgpt.com/codex/tasks/task_e_689cc4347ba88321bf63149ac8cf9d2a