### PR TITLE
feat: snapshot export with manifest and idempotency test

### DIFF
--- a/src/lib/snapshot.js
+++ b/src/lib/snapshot.js
@@ -1,0 +1,26 @@
+import { promises as fs } from 'fs';
+import { join, dirname } from 'path';
+import { createHash } from 'crypto';
+
+/**
+ * Create snapshot files on disk.
+ * @param {Array<{target:string, lang:string, content:string}>} files
+ * @param {string=} ts optional timestamp (ISO-like, sanitized) for deterministic paths
+ * @returns {Promise<{timestamp:string, files:Array<{path:string, sha256:string, target:string, lang:string, timestamp:string}>}>}
+ */
+export async function createSnapshot(files, ts) {
+  const timestamp = ts || new Date().toISOString().replace(/[:.]/g, '-');
+  const baseDir = join(process.cwd(), 'snapshots', timestamp);
+  const manifest = [];
+  for (const f of files) {
+    const relPath = `paper/${f.target}/${f.lang}/draft.tex`;
+    const absPath = join(baseDir, relPath);
+    await fs.mkdir(dirname(absPath), { recursive: true });
+    const data = Buffer.from(f.content);
+    await fs.writeFile(absPath, data);
+    const sha256 = createHash('sha256').update(data).digest('hex');
+    manifest.push({ path: relPath, sha256, target: f.target, lang: f.lang, timestamp });
+  }
+  await fs.writeFile(join(baseDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  return { timestamp, files: manifest };
+}

--- a/tests/snapshot.test.js
+++ b/tests/snapshot.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createSnapshot } from '../src/lib/snapshot.js';
+import { rm } from 'fs/promises';
+import { join } from 'path';
+
+test('snapshot generation is idempotent', async () => {
+  const files = [{ target: 'demo', lang: 'en', content: 'hello world' }];
+  const first = await createSnapshot(files);
+  const second = await createSnapshot(files);
+  assert.equal(first.files[0].sha256, second.files[0].sha256);
+  // cleanup
+  await rm(join('snapshots', first.timestamp), { recursive: true, force: true });
+  await rm(join('snapshots', second.timestamp), { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add Node-powered snapshot mode to export API that writes files to `snapshots/<timestamp>` and returns manifest
- implement filesystem snapshot utility and idempotency test

## Testing
- `node --test tests/snapshot.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689c003c0864832194850803fb73c74c