### PR TITLE
feat: add export history panel

### DIFF
--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { useEffect, useState } from "react";
+import JSZip from "jszip";
+import { loadHistory, Snapshot } from "../lib/utils/history";
+
+function b64ToBlob(b64: string, type: string) {
+  const bin = atob(b64);
+  const u8 = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i);
+  return new Blob([u8], { type });
+}
+
+export default function HistoryPanel({ onClose }: { onClose: () => void }) {
+  const [items, setItems] = useState<Snapshot[]>([]);
+
+  useEffect(() => {
+    setItems(loadHistory());
+  }, []);
+
+  async function download(item: Snapshot) {
+    const blob = b64ToBlob(item.zip, "application/zip");
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = item.target;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function openPath(item: Snapshot, path: string) {
+    try {
+      const zip = await JSZip.loadAsync(b64ToBlob(item.zip, "application/zip"));
+      const file = zip.file(path);
+      if (!file) return;
+      const blob = await file.async("blob");
+      const url = URL.createObjectURL(blob);
+      window.open(url, "_blank");
+    } catch {}
+  }
+
+  return (
+    <div style={{ position: "fixed", top: 0, right: 0, bottom: 0, width: 320, background: "var(--panel)", borderLeft: "1px solid #242938", padding: 16, overflow: "auto", zIndex: 1000 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+        <strong>History</strong>
+        <button className="btn" onClick={onClose}>×</button>
+      </div>
+      {items.map((it, idx) => (
+        <div key={idx} style={{ marginBottom: 16, borderBottom: "1px solid #242938", paddingBottom: 12 }}>
+          <div style={{ fontSize: 13, marginBottom: 6 }}>{new Date(it.timestamp).toLocaleString()} • {it.target} • {it.lang}</div>
+          <div className="actions" style={{ marginBottom: 6 }}>
+            <button className="btn" onClick={() => download(it)}>ZIP</button>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            {it.paths.map(p => (
+              <button key={p} className="btn" style={{ textAlign: "left" }} onClick={() => openPath(it, p)}>{p}</button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/utils/history.ts
+++ b/src/lib/utils/history.ts
@@ -1,0 +1,26 @@
+import { getLocal, setLocal } from "./store";
+
+export type Snapshot = {
+  timestamp: string;
+  target: string;
+  lang: string;
+  paths: string[];
+  zip: string; // base64
+};
+
+const KEY = "QAADI_HISTORY";
+
+export function loadHistory(): Snapshot[] {
+  try {
+    return JSON.parse(getLocal(KEY, "[]"));
+  } catch {
+    return [];
+  }
+}
+
+export function addHistory(entry: Snapshot) {
+  const list = loadHistory();
+  list.unshift(entry);
+  // keep only latest 20
+  setLocal(KEY, JSON.stringify(list.slice(0, 20)));
+}


### PR DESCRIPTION
## Summary
- store export snapshots in localStorage with timestamp, target, language and paths
- add HistoryPanel component to browse past exports and download files
- add History button on main page to toggle panel and view history

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Module not found: Can't resolve 'zod')*

------
https://chatgpt.com/codex/tasks/task_e_689cc4371ae48321a1cafe5de7ee89a4