### PR TITLE
feat: stream generation with progress UI

### DIFF
--- a/tests/stream.test.js
+++ b/tests/stream.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+const encoder = new TextEncoder();
+
+test('collects streamed chunks into final output', async () => {
+  const text = 'streaming works';
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(JSON.stringify({ type: 'meta', total: text.length }) + '\n'));
+      controller.enqueue(encoder.encode(JSON.stringify({ type: 'chunk', data: text, sent: text.length }) + '\n'));
+      controller.enqueue(encoder.encode(JSON.stringify({ type: 'done' }) + '\n'));
+      controller.close();
+    }
+  });
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let out = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const j = JSON.parse(line);
+      if (j.type === 'chunk') out += j.data;
+    }
+  }
+  assert.equal(out, text);
+});


### PR DESCRIPTION
## Summary
- stream `/api/generate` responses using `ReadableStream` so text is emitted chunk by chunk
- update the main page to progressively render streamed text and show a progress bar
- add a small node test ensuring streamed chunks accumulate to final output

## Testing
- `npm run build` *(fails: Cannot find module 'zod')*
- `npm install zod` *(fails: 403 Forbidden)*
- `node --test tests/stream.test.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cc43978d483218dbbea527f2360c0