### PR TITLE
feat: add target and language selections

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
+import JSZip from "jszip";
 
 type Template = "WideAR" | "ReVTeX" | "InquiryTR";
 type ModelSel = "openai" | "deepseek" | "auto";
@@ -10,13 +11,23 @@ export default function Editor() {
 
   const [template, setTemplate] = useState<Template>("ReVTeX");
   const [model, setModel] = useState<ModelSel>("auto");
+  const [target, setTarget] = useState("");
+  const [language, setLanguage] = useState("");
   const [maxTokens, setMaxTokens] = useState(2048);
   const [text, setText] = useState("");
 
   const [out, setOut] = useState<string>("");
+  const [prevOut, setPrevOut] = useState<string>("");
   const [busy, setBusy] = useState(false);
   const [zipBusy, setZipBusy] = useState(false);
   const [msg, setMsg] = useState<string>("");
+  const [files, setFiles] = useState<string[]>([]);
+  const [verify, setVerify] = useState({
+    equations_count: 0,
+    glossary_applied: false,
+    rtl_ltr: "",
+    idempotency: false
+  });
 
   useEffect(() => {
     try {
@@ -35,22 +46,26 @@ export default function Editor() {
 
   async function doGenerate() {
     setBusy(true); setMsg("");
+    const previous = out;
     try {
       const res = await fetch("/api/generate", {
         method: "POST",
         headers,
-        body: JSON.stringify({ template, model, max_tokens: maxTokens, text })
+        body: JSON.stringify({ template, model, max_tokens: maxTokens, text, target, language })
       });
       const j = await res.json();
       if (!res.ok) throw new Error(j?.error || "generate_failed");
-      setOut(j?.text || "");
+      const newOut = j?.text || "";
+      setPrevOut(previous);
+      setOut(newOut);
+      setVerify(analyze(newOut, previous));
       setMsg(`OK • model=${j?.model_used} • in=${j?.tokens_in} • out=${j?.tokens_out} • ${j?.latency_ms}ms`);
     } catch (e:any) {
       setMsg(`ERROR: ${e?.message || e}`);
     } finally { setBusy(false); }
   }
 
-  async function exportOrchestrate() {
+  async function exportZip() {
     setZipBusy(true); setMsg("");
     try {
       const res = await fetch("/api/export", {
@@ -69,40 +84,16 @@ export default function Editor() {
         throw new Error(j?.error || `status_${res.status}`);
       }
       const blob = await res.blob();
+      listFilesFromZip(blob);
       downloadBlob(blob, "qaadi_export.zip");
-      setMsg("ZIP جاهز (orchestrate).");
+      setMsg("ZIP جاهز.");
     } catch (e:any) {
       setMsg(`EXPORT ERROR: ${e?.message || e}`);
     } finally { setZipBusy(false); }
   }
 
-  async function exportCompose() {
-    setZipBusy(true); setMsg("");
-    try {
-      const res = await fetch("/api/export", {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          mode: "compose",
-          name: "qaadi_export.zip",
-          input: { text },
-          secretary: { audit: { ready_percent: 50, issues: [{ type: "demo", note: "example only" }] } },
-          judge: { report: { score_total: 110, criteria: [], notes: "demo" } },
-          consultant: { plan: out || "plan(demo)" },
-          journalist: { summary: (out && out.slice(0, 400)) || "summary(demo)" },
-          meta: { template, model, max_tokens: maxTokens }
-        })
-      });
-      if (!res.ok) {
-        const j = await res.json().catch(() => ({}));
-        throw new Error(j?.error || `status_${res.status}`);
-      }
-      const blob = await res.blob();
-      downloadBlob(blob, "qaadi_export.zip");
-      setMsg("ZIP جاهز (compose).");
-    } catch (e:any) {
-      setMsg(`EXPORT ERROR: ${e?.message || e}`);
-    } finally { setZipBusy(false); }
+  function openSnapshot() {
+    window.open("/snapshot", "_blank");
   }
 
   function downloadBlob(blob: Blob, name: string) {
@@ -110,6 +101,23 @@ export default function Editor() {
     const a = document.createElement("a");
     a.href = url; a.download = name; a.click();
     URL.revokeObjectURL(url);
+  }
+
+  async function listFilesFromZip(blob: Blob) {
+    try {
+      const zip = await JSZip.loadAsync(blob);
+      setFiles(Object.keys(zip.files));
+    } catch {
+      setFiles([]);
+    }
+  }
+
+  function analyze(text: string, prev: string) {
+    const equations_count = (text.match(/\$[^$]+\$/g) || []).length;
+    const glossary_applied = /\\gls\{/.test(text);
+    const rtl_ltr = /[\u0600-\u06FF]/.test(text) ? "rtl" : "ltr";
+    const idempotency = prev === text && text !== "";
+    return { equations_count, glossary_applied, rtl_ltr, idempotency };
   }
 
   return (
@@ -148,6 +156,27 @@ export default function Editor() {
         </div>
       </div>
 
+      <div className="card grid grid-2" style={{marginBottom:12}}>
+        <div>
+          <label>Target</label>
+          <select value={target} onChange={e=>setTarget(e.target.value)}>
+            <option value="" disabled hidden>اختر الهدف</option>
+            <option value="paper">Paper</option>
+            <option value="report">Report</option>
+            <option value="summary">Summary</option>
+          </select>
+        </div>
+        <div>
+          <label>Language</label>
+          <select value={language} onChange={e=>setLanguage(e.target.value)}>
+            <option value="" disabled hidden>Select language</option>
+            <option value="ar">Arabic</option>
+            <option value="en">English</option>
+            <option value="tr">Turkish</option>
+          </select>
+        </div>
+      </div>
+
       <div className="card" style={{marginBottom:12}}>
         <label>النص</label>
         <textarea rows={12} placeholder="ألصق هنا النص المبعثر…" value={text} onChange={e=>setText(e.target.value)} />
@@ -155,12 +184,30 @@ export default function Editor() {
 
       <div className="card" style={{marginBottom:12}}>
         <div className="actions">
-          <button className="btn" onClick={exportCompose} disabled={zipBusy}>{zipBusy ? "..." : "Export (compose demo)"}</button>
-          <button className="btn btn-primary" onClick={exportOrchestrate} disabled={zipBusy}>{zipBusy ? "..." : "Export (orchestrate)"}</button>
-          <button className="btn" onClick={doGenerate} disabled={busy}>{busy ? "جارٍ…" : "Generate"}</button>
+          <button className="btn" onClick={openSnapshot}>Open Snapshot</button>
+          <button className="btn" onClick={exportZip} disabled={zipBusy}>{zipBusy ? "..." : "Export ZIP"}</button>
+          <button className="btn btn-primary" onClick={doGenerate} disabled={busy || !target || !language}>{busy ? "جارٍ…" : "Generate"}</button>
         </div>
         {msg && <div className="note">{msg}</div>}
       </div>
+
+      {out && (
+        <div className="card grid grid-4" style={{marginBottom:12}}>
+          <div>equations_count: {verify.equations_count}</div>
+          <div>glossary_applied: {verify.glossary_applied ? "yes" : "no"}</div>
+          <div>rtl_ltr: {verify.rtl_ltr}</div>
+          <div>idempotency: {verify.idempotency ? "stable" : "changed"}</div>
+        </div>
+      )}
+
+      {files.length > 0 && (
+        <div className="card" style={{marginBottom:12}}>
+          <label>Files</label>
+          <ul>
+            {files.map(f => <li key={f}>{f}</li>)}
+          </ul>
+        </div>
+      )}
 
       <div className="card">
         <label>Output</label>


### PR DESCRIPTION
## Summary
- add Target and Language selectors to the editor and require both before generating
- show verification metrics for generated text and list exported files
- provide secondary actions for exporting ZIPs and opening snapshots

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot resolve 'zod')*


------
https://chatgpt.com/codex/tasks/task_e_689db2d0a5388321b18ac33e2a1f5e37