### PR TITLE
feat: add language context and dynamic html attrs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,30 @@
+"use client";
+
 import "./globals.css";
+import { useState, useEffect } from "react";
+import { LanguageContext, Language } from "../context/LanguageContext";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const [lang, setLang] = useState<Language>("ar");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("lang");
+    if (stored === "ar" || stored === "en") {
+      setLang(stored);
+    }
+  }, []);
+
+  const setLanguage = (language: Language) => {
+    setLang(language);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("lang", language);
+    }
+  };
+
+  const dir = lang === "ar" ? "rtl" : "ltr";
+
   return (
-    <html lang="ar" dir="rtl">
+    <html lang={lang} dir={dir}>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Qaadi Live</title>
@@ -23,7 +45,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body>
-        <div className="wrapper">{children}</div>
+        <LanguageContext.Provider value={{ lang, dir, setLanguage }}>
+          <div className="wrapper">{children}</div>
+        </LanguageContext.Provider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,23 @@
+"use client";
+
 import Header from "../components/Header";
 import Editor from "../components/Editor";
 import Footer from "../components/Footer";
+import { useLanguage } from "../context/LanguageContext";
 
 export default function Page() {
+  const { lang, setLanguage } = useLanguage();
+
   return (
     <>
+      <select
+        value={lang}
+        onChange={(e) => setLanguage(e.target.value as "ar" | "en")}
+        style={{ margin: "1rem" }}
+      >
+        <option value="ar">العربية</option>
+        <option value="en">English</option>
+      </select>
       <Header />
       <Editor />
       <Footer />

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+export type Language = "ar" | "en";
+export type LangContextType = {
+  lang: Language;
+  dir: "rtl" | "ltr";
+  setLanguage: (lang: Language) => void;
+};
+
+export const LanguageContext = createContext<LangContextType>({
+  lang: "ar",
+  dir: "rtl",
+  setLanguage: () => {},
+});
+
+export const useLanguage = () => useContext(LanguageContext);


### PR DESCRIPTION
## Summary
- add language context provider for user-selected language and direction
- apply dynamic lang and dir attributes to root html element
- expose selector on main page to switch languages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Module not found: Can't resolve 'zod')*

------
https://chatgpt.com/codex/tasks/task_e_689db12a51ec83218849f5b672725c41