### PR TITLE
feat: expose verification and zip export

### DIFF
--- a/src/app/api/download/zip/route.ts
+++ b/src/app/api/download/zip/route.ts
@@ -1,0 +1,21 @@
+import { getSnapshot } from "../../../../lib/snapshot";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const snap = getSnapshot();
+  if (!snap.zip) {
+    return new Response(JSON.stringify({ error: "no_snapshot" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+  return new Response(snap.zip, {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename="${snap.name}"`,
+      "Cache-Control": "no-store",
+      "X-Content-Type-Options": "nosniff"
+    }
+  });
+}

--- a/src/app/api/snapshot/export/route.ts
+++ b/src/app/api/snapshot/export/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+import { makeZip, ZipFile } from "../../../../lib/utils/zip";
+import { setSnapshot } from "../../../../lib/snapshot";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "bad_input" }), { status: 400, headers: { "Content-Type": "application/json" } });
+  }
+
+  const text = String(body?.text ?? "").trim();
+  const verification = {
+    equations_count: (text.match(/\$/g) || []).length / 2,
+    glossary_applied: /glossary/i.test(text)
+  };
+
+  const files: ZipFile[] = [
+    { path: "paper/10_input.md", content: text },
+    { path: "paper/20_verification.json", content: JSON.stringify(verification, null, 2) }
+  ];
+  const zip = makeZip(files);
+  setSnapshot(zip, "qaadi_export.zip", verification);
+
+  return new Response(JSON.stringify({ ok: true, verification }), {
+    headers: { "Content-Type": "application/json" }
+  });
+}

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,0 +1,19 @@
+export type SnapshotState = {
+  zip: Uint8Array | null;
+  name: string;
+  verification: any | null;
+};
+
+let state: SnapshotState = {
+  zip: null,
+  name: "qaadi_export.zip",
+  verification: null,
+};
+
+export function setSnapshot(zip: Uint8Array, name: string, verification: any) {
+  state = { zip, name, verification };
+}
+
+export function getSnapshot() {
+  return state;
+}


### PR DESCRIPTION
## Summary
- display verification results from snapshot export
- add button to export ZIP via snapshot and download API
- implement snapshot export and download server routes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Can't resolve 'zod')

------
https://chatgpt.com/codex/tasks/task_e_689cc7efeb888321b7a4ba5ef9398bcb