### PR TITLE
Add basic layout and editor components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,8 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
+import Editor from "../components/Editor";
 
 type Template = "WideAR" | "ReVTeX" | "InquiryTR";
 type ModelSel = "openai" | "deepseek" | "auto";
@@ -114,7 +117,7 @@ export default function Page() {
 
   return (
     <>
-      <h1 className="h1"><span className="badge">⚖️</span> Qaadi Live</h1>
+      <Header />
 
       <div className="card grid grid-2" style={{marginBottom:12}}>
         <div>
@@ -150,10 +153,7 @@ export default function Page() {
         </div>
       </div>
 
-      <div className="card" style={{marginBottom:12}}>
-        <label>النص</label>
-        <textarea rows={12} placeholder="ألصق هنا النص المبعثر…" value={text} onChange={e=>setText(e.target.value)} />
-      </div>
+      <Editor text={text} onTextChange={setText} />
 
       <div className="card" style={{marginBottom:12}}>
         <div className="actions">
@@ -168,6 +168,7 @@ export default function Page() {
         <label>Output</label>
         <textarea className="output" value={out} readOnly />
       </div>
+      <Footer />
     </>
   );
 }

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,0 +1,25 @@
+"use client";
+import type { ChangeEvent } from "react";
+
+interface EditorProps {
+  text: string;
+  onTextChange: (value: string) => void;
+}
+
+export default function Editor({ text, onTextChange }: EditorProps) {
+  function handleChange(e: ChangeEvent<HTMLTextAreaElement>) {
+    onTextChange(e.target.value);
+  }
+
+  return (
+    <div className="card" style={{ marginBottom: 12 }}>
+      <label>النص</label>
+      <textarea
+        rows={12}
+        placeholder="ألصق هنا النص المبعثر…"
+        value={text}
+        onChange={handleChange}
+      />
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function Footer() {
+  return (
+    <footer style={{ marginTop: 24, textAlign: "center" }}>
+      <small>© {new Date().getFullYear()} Qaadi Live</small>
+    </footer>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+export default function Header() {
+  return (
+    <header>
+      <h1 className="h1">
+        <span className="badge">⚖️</span> Qaadi Live
+      </h1>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add Header, Footer, and Editor components for structured layout
- replace inline text area with reusable Editor component
- wire new components into main page

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689cc7e289a88321b5af80a99b9c6b49