### PR TITLE
feat: add dynamic language context for layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,12 @@
-import "./globals.css";
+"use client";
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+import "./globals.css";
+import { LanguageProvider, useLanguage } from "../lib/LanguageContext";
+
+function LayoutInner({ children }: { children: React.ReactNode }) {
+  const { lang, dir } = useLanguage();
   return (
-    <html lang="ar" dir="rtl">
+    <html lang={lang} dir={dir}>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Qaadi Live</title>
@@ -26,5 +30,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="wrapper">{children}</div>
       </body>
     </html>
+  );
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <LanguageProvider>
+      <LayoutInner>{children}</LayoutInner>
+    </LanguageProvider>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,19 @@
+"use client";
+
 import Header from "../components/Header";
 import Editor from "../components/Editor";
 import Footer from "../components/Footer";
+import { useLanguage } from "../lib/LanguageContext";
 
 export default function Page() {
+  const { setLanguage } = useLanguage();
   return (
     <>
       <Header />
+      <div>
+        <button onClick={() => setLanguage("ar")}>العربية</button>
+        <button onClick={() => setLanguage("en")}>English</button>
+      </div>
       <Editor />
       <Footer />
     </>

--- a/src/lib/LanguageContext.tsx
+++ b/src/lib/LanguageContext.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useState } from "react";
+
+interface LanguageContextValue {
+  lang: string;
+  dir: "ltr" | "rtl";
+  setLanguage: (lang: string) => void;
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [lang, setLang] = useState("ar");
+
+  const setLanguage = (nextLang: string) => {
+    setLang(nextLang);
+  };
+
+  const dir: "ltr" | "rtl" = lang === "ar" ? "rtl" : "ltr";
+
+  return (
+    <LanguageContext.Provider value={{ lang, dir, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add LanguageContext to manage HTML lang and dir
- update layout to consume context for html attributes
- allow language selection on main page via context

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689db2ce8f9c8321a5228c61a919bbbb