### PR TITLE
feat: add language context

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,12 @@
-import "./globals.css";
+"use client";
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+import "./globals.css";
+import { LanguageProvider, useLanguage } from "../lib/LanguageContext";
+
+function LayoutInner({ children }: { children: React.ReactNode }) {
+  const { lang, dir } = useLanguage();
   return (
-    <html lang="ar" dir="rtl">
+    <html lang={lang} dir={dir}>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Qaadi Live</title>
@@ -26,5 +30,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="wrapper">{children}</div>
       </body>
     </html>
+  );
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <LanguageProvider>
+      <LayoutInner>{children}</LayoutInner>
+    </LanguageProvider>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
+import { useLanguage } from "../lib/LanguageContext";
 
 type Template = "WideAR" | "ReVTeX" | "InquiryTR";
 type ModelSel = "openai" | "deepseek" | "auto";
@@ -17,6 +18,14 @@ export default function Page() {
   const [busy, setBusy] = useState(false);
   const [zipBusy, setZipBusy] = useState(false);
   const [msg, setMsg] = useState<string>("");
+
+  const { setLang, setDir } = useLanguage();
+  const [language, setLanguage] = useState("ar");
+
+  useEffect(() => {
+    setLang(language);
+    setDir(language === "ar" ? "rtl" : "ltr");
+  }, [language, setLang, setDir]);
 
   useEffect(() => {
     try {
@@ -115,6 +124,14 @@ export default function Page() {
   return (
     <>
       <h1 className="h1"><span className="badge">⚖️</span> Qaadi Live</h1>
+
+      <div className="card" style={{marginBottom:12}}>
+        <label>اللغة</label>
+        <select value={language} onChange={e=>setLanguage(e.target.value)}>
+          <option value="ar">العربية</option>
+          <option value="en">English</option>
+        </select>
+      </div>
 
       <div className="card grid grid-2" style={{marginBottom:12}}>
         <div>

--- a/src/lib/LanguageContext.tsx
+++ b/src/lib/LanguageContext.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface LanguageContextType {
+  lang: string;
+  dir: "ltr" | "rtl";
+  setLang: (lang: string) => void;
+  setDir: (dir: "ltr" | "rtl") => void;
+}
+
+const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState("ar");
+  const [dir, setDir] = useState<"ltr" | "rtl">("rtl");
+
+  return (
+    <LanguageContext.Provider value={{ lang, dir, setLang, setDir }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error("useLanguage must be used within LanguageProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add LanguageContext for shared lang/dir state
- update RootLayout to read lang/dir from context
- expose language selection in page and sync with layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Module not found: Can't resolve 'zod')

------
https://chatgpt.com/codex/tasks/task_e_689cc7e6bad08321bc451fc9a6263646