### PR TITLE
feat: add snapshot API and manifest support

### DIFF
--- a/src/app/api/snapshot/route.ts
+++ b/src/app/api/snapshot/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from "next/server";
+import { createSnapshot, SnapshotInput } from "../../../lib/snapshot";
+
+export const runtime = "nodejs";
+
+function headersJSON() {
+  return {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store",
+    "X-Content-Type-Options": "nosniff",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type"
+  };
+}
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: headersJSON() });
+}
+
+export async function POST(req: NextRequest) {
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "bad_input" }), { status: 400, headers: headersJSON() });
+  }
+
+  const files = Array.isArray(body?.files) ? (body.files as SnapshotInput[]) : null;
+  if (!files || !files.length) {
+    return new Response(JSON.stringify({ error: "no_files" }), { status: 400, headers: headersJSON() });
+  }
+
+  try {
+    const snap = await createSnapshot(files);
+    return new Response(JSON.stringify({ manifest: snap.manifest, timestamp: snap.timestamp }), {
+      status: 200,
+      headers: headersJSON()
+    });
+  } catch (e: any) {
+    return new Response(JSON.stringify({ error: "snapshot_failed", detail: e?.message || String(e) }), {
+      status: 500,
+      headers: headersJSON()
+    });
+  }
+}

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,0 +1,38 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { createHash } from 'crypto';
+
+export type SnapshotInput = {
+  target: string;
+  lang: string;
+  path: string;
+  content: string;
+};
+
+export type ManifestEntry = {
+  path: string;
+  sha256: string;
+  target: string;
+  lang: string;
+  timestamp: string;
+};
+
+export async function createSnapshot(files: SnapshotInput[]) {
+  const timestamp = new Date().toISOString();
+  const baseDir = path.join(process.cwd(), 'snapshots', timestamp);
+  await fs.mkdir(baseDir, { recursive: true });
+
+  const manifest: ManifestEntry[] = [];
+
+  for (const f of files) {
+    const relPath = path.join('paper', f.target, f.lang, f.path).replace(/\\/g, '/');
+    const outPath = path.join(baseDir, relPath);
+    await fs.mkdir(path.dirname(outPath), { recursive: true });
+    await fs.writeFile(outPath, f.content, 'utf8');
+    const sha256 = createHash('sha256').update(f.content).digest('hex');
+    manifest.push({ path: relPath, sha256, target: f.target, lang: f.lang, timestamp });
+  }
+
+  await fs.writeFile(path.join(baseDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  return { dir: baseDir, manifest, timestamp };
+}

--- a/tests/idempotency.ts
+++ b/tests/idempotency.ts
@@ -1,0 +1,17 @@
+import * as assert from 'assert';
+import { createSnapshot, SnapshotInput } from '../src/lib/snapshot';
+
+async function main() {
+  const files: SnapshotInput[] = [
+    { target: 'demo', lang: 'en', path: 'hello.txt', content: 'hello world' },
+    { target: 'demo', lang: 'ar', path: 'salam.txt', content: 'مرحبا' }
+  ];
+  const a = await createSnapshot(files);
+  const b = await createSnapshot(files);
+  const hashesA = a.manifest.map(f => f.sha256);
+  const hashesB = b.manifest.map(f => f.sha256);
+  assert.deepStrictEqual(hashesA, hashesB);
+  console.log('idempotent hashes:', hashesA);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add snapshot utility to persist generated files and manifest entries
- expose new `/api/snapshot` endpoint to create timestamped snapshots
- include idempotency test to verify stable sha256 hashes

## Testing
- `npm test` *(fails: Missing script)*
- `node tests-dist/tests/idempotency.cjs`

------
https://chatgpt.com/codex/tasks/task_e_689da0ab67cc8321b10ac2d60630bc44