### PR TITLE
feat: add dynamic language and direction

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,12 @@
-import "./globals.css";
+'use client';
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+import "./globals.css";
+import { LanguageProvider, useLanguage } from "../components/LanguageProvider";
+
+function AppLayout({ children }: { children: React.ReactNode }) {
+  const { lang, dir } = useLanguage();
   return (
-    <html lang="ar" dir="rtl">
+    <html lang={lang} dir={dir}>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Qaadi Live</title>
@@ -28,3 +32,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     </html>
   );
 }
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <LanguageProvider>
+      <AppLayout>{children}</AppLayout>
+    </LanguageProvider>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,23 @@
+'use client';
+
 import Header from "../components/Header";
 import Editor from "../components/Editor";
 import Footer from "../components/Footer";
+import { useLanguage } from "../components/LanguageProvider";
 
 export default function Page() {
+  const { lang, setLang } = useLanguage();
+  const toggleLanguage = () => setLang(lang === 'ar' ? 'en' : 'ar');
+
   return (
     <>
       <Header />
+      <button onClick={toggleLanguage}>
+        {lang === 'ar' ? 'Switch to English' : 'التبديل إلى العربية'}
+      </button>
       <Editor />
       <Footer />
     </>
   );
 }
+

--- a/src/components/LanguageProvider.tsx
+++ b/src/components/LanguageProvider.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { createContext, useContext, useState } from 'react';
+
+interface LanguageContextProps {
+  lang: string;
+  dir: 'ltr' | 'rtl';
+  setLang: (lang: string) => void;
+}
+
+const LanguageContext = createContext<LanguageContextProps | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [lang, setLang] = useState<'ar' | 'en'>('ar');
+  const dir: 'ltr' | 'rtl' = lang === 'ar' ? 'rtl' : 'ltr';
+
+  return (
+    <LanguageContext.Provider value={{ lang, dir, setLang }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within LanguageProvider');
+  }
+  return context;
+}
+


### PR DESCRIPTION
## Summary
- add language context to manage locale and direction
- use context values to set `<html>` `lang` and `dir`
- add page-level control to toggle language

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Module not found: Can't resolve 'zod')

------
https://chatgpt.com/codex/tasks/task_e_689da0aa68f483219d3197407b0db1be