### PR TITLE
feat: persist export snapshots with manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 dist
 *.key
 *.pem
+snapshots


### PR DESCRIPTION
## Summary
- store exported files under timestamped `snapshots/<ts>/paper/<target>/<lang>` directories
- maintain `snapshots/manifest.json` with path, sha256, target, lang, timestamp
- ignore generated snapshot data in Git

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dd2a165a88321a7ee5ce57ec52e98