### PR TITLE
refactor: split template into target and language

### DIFF
--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -53,7 +53,7 @@ function buildTreeFromCompose(payload: any) {
   //   judge?: { report: any },
   //   consultant?: { plan: string },
   //   journalist?: { summary: string },
-  //   meta?: { template?: string, model?: string, max_tokens?: number }
+  //   meta?: { target?: string, lang?: string, model?: string, max_tokens?: number }
   // }
   const files: ZipFile[] = [];
   const name = typeof payload?.name === "string" ? payload.name : "qaadi_export.zip";

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,6 +31,7 @@ body{
 .grid{display:grid;gap:var(--gap)}
 .grid-2{grid-template-columns:1fr 1fr}
 .grid-3{grid-template-columns:1fr 1fr 1fr}
+.grid-4{grid-template-columns:1fr 1fr 1fr 1fr}
 label{display:block;font-size:12px;color:var(--muted);margin-bottom:6px}
 input,select,textarea{
   width:100%; background:#0f131a; color:var(--text);

--- a/src/lib/schema/io.ts
+++ b/src/lib/schema/io.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
 export const InputSchema = z.object({
-  template: z.enum(["WideAR", "ReVTeX", "InquiryTR"]).default("ReVTeX"),
+  target: z.enum(["wide", "revtex", "inquiry"]),
+  lang: z.enum(["ar", "en", "tr"]),
   model: z.enum(["openai", "deepseek", "auto"]).default("auto"),
   max_tokens: z.number().int().min(256).max(8192).default(2048),
   text: z.string().min(1)


### PR DESCRIPTION
## Summary
- replace `template` input with separate `target` and `lang` fields
- update editor and generate API to require both fields and handle missing selections
- add UI dropdowns and validation message when target or language omitted

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dd2a45a7c83219a23fbdab347cf38