### PR TITLE
Initialize lang and dir before React renders

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ar" dir="rtl">
       <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{var l=localStorage.getItem('lang');if(l)document.documentElement.lang=l;var d=localStorage.getItem('dir');if(d)document.documentElement.dir=d;}catch(e){}`
+          }}
+        />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Qaadi Live</title>
         <meta name="theme-color" content="#111111" />


### PR DESCRIPTION
## Summary
- Read `lang` and `dir` from `localStorage` via a head script so the document attributes update before React hydrates.
- Simplifies layout by removing the need for a runtime `useEffect`.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: next: not found)*
- `npm install --no-progress` *(fails: 403 Forbidden - GET https://registry.npmjs.org/zod)*

------
https://chatgpt.com/codex/tasks/task_e_689dd9a942f48321b91a7f5e7ac79c01