### PR TITLE
feat: compute determinism and provenance data

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "node --loader ts-node/esm --test test/**/*.ts"
   },
   "dependencies": {
     "next": "14.2.5",
@@ -17,6 +18,7 @@
   "devDependencies": {
     "typescript": "5.4.5",
     "@types/react": "18.2.66",
-    "@types/node": "20.11.30"
+    "@types/node": "20.11.30",
+    "ts-node": "10.9.2"
   }
 }

--- a/test/download-zip.test.ts
+++ b/test/download-zip.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { GET } from '../src/app/api/download/zip/route';
+import { NextRequest } from 'next/server';
+
+function unzipStore(u8: Uint8Array): Record<string, Uint8Array> {
+  const view32 = (i: number) => new DataView(u8.buffer, u8.byteOffset + i, 4).getUint32(0, true);
+  const view16 = (i: number) => new DataView(u8.buffer, u8.byteOffset + i, 2).getUint16(0, true);
+  let p = 0;
+  const out: Record<string, Uint8Array> = {};
+  while (p + 4 <= u8.length && view32(p) === 0x04034b50) {
+    const nameLen = view16(p + 26);
+    const extraLen = view16(p + 28);
+    const size = view32(p + 18);
+    const nameBytes = u8.slice(p + 30, p + 30 + nameLen);
+    const name = Buffer.from(nameBytes).toString();
+    const start = p + 30 + nameLen + extraLen;
+    out[name] = u8.slice(start, start + size);
+    p = start + size;
+  }
+  return out;
+}
+
+test('determinism and provenance non-empty', async () => {
+  const req = new NextRequest('http://localhost/api/download/zip?slug=demo&v=v1.0');
+  const res = await GET(req);
+  assert.strictEqual(res.status, 200);
+  const buf = Buffer.from(await res.arrayBuffer());
+  const files = unzipStore(buf);
+  const determinism = JSON.parse(Buffer.from(files['determinism_matrix.json']).toString());
+  const provenance = JSON.parse(Buffer.from(files['provenance.json']).toString());
+  assert.ok(Array.isArray(determinism.matrix) && determinism.matrix.length > 0);
+  assert.ok(Array.isArray(provenance.sources) && provenance.sources.length > 0);
+});


### PR DESCRIPTION
## Summary
- build determinism matrix from existing snapshots or fall back to a single snapshot
- record source file hashes in provenance metadata
- test zip download includes non-empty determinism and provenance data

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_689de121feb08321b44d540ca92747cb