### PR TITLE
feat: enhance verify bar and snapshot listing

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -19,7 +19,8 @@ export default function Editor() {
   const [busy, setBusy] = useState(false);
   const [zipBusy, setZipBusy] = useState(false);
   const [msg, setMsg] = useState<string>("");
-  const [verify, setVerify] = useState<null | { eq_before:number; eq_after:number; eq_match:boolean; glossary_entries:number }>(null);
+  const [verify, setVerify] = useState<null | { eq_before:number; eq_after:number; eq_match:boolean; glossary_entries:number; rtl_ltr:string; idempotency:boolean }>(null);
+  const [files, setFiles] = useState<string[]>([]);
 
   useEffect(() => {
     try {
@@ -50,6 +51,7 @@ export default function Editor() {
       setOut(j?.text || "");
       setVerify(j?.checks || null);
       setMsg(`OK • model=${j?.model_used} • in=${j?.tokens_in} • out=${j?.tokens_out} • ${j?.latency_ms}ms`);
+      await refreshFiles();
     } catch (e:any) {
       setMsg(e?.message === "missing_target_lang" ? "يرجى اختيار الهدف واللغة" : `ERROR: ${e?.message || e}`);
       setVerify(null);
@@ -77,6 +79,7 @@ export default function Editor() {
       const blob = await res.blob();
       downloadBlob(blob, "qaadi_export.zip");
       setMsg("ZIP جاهز (orchestrate).");
+      await refreshFiles();
     } catch (e:any) {
       setMsg(`EXPORT ERROR: ${e?.message || e}`);
     } finally { setZipBusy(false); }
@@ -107,6 +110,7 @@ export default function Editor() {
       const blob = await res.blob();
       downloadBlob(blob, "qaadi_export.zip");
       setMsg("ZIP جاهز (compose).");
+      await refreshFiles();
     } catch (e:any) {
       setMsg(e?.message === "missing_target_lang" ? "يرجى اختيار الهدف واللغة" : `EXPORT ERROR: ${e?.message || e}`);
     } finally { setZipBusy(false); }
@@ -117,6 +121,19 @@ export default function Editor() {
     const a = document.createElement("a");
     a.href = url; a.download = name; a.click();
     URL.revokeObjectURL(url);
+  }
+
+  async function refreshFiles() {
+    try {
+      const res = await fetch("/snapshots/manifest.json");
+      if (!res.ok) { setFiles([]); return; }
+      const list = await res.json();
+      if (Array.isArray(list) && list.length) {
+        const latest = list.reduce((m:any, c:any) => c.timestamp > m ? c.timestamp : m, "");
+        const fl = list.filter((f:any) => f.timestamp === latest).map((f:any) => f.path);
+        setFiles(fl);
+      } else setFiles([]);
+    } catch { setFiles([]); }
   }
 
   return (
@@ -175,6 +192,8 @@ export default function Editor() {
           <button className="btn" onClick={exportCompose} disabled={zipBusy}>{zipBusy ? "..." : "Export (compose demo)"}</button>
           <button className="btn btn-primary" onClick={exportOrchestrate} disabled={zipBusy}>{zipBusy ? "..." : "Export (orchestrate)"}</button>
           <button className="btn" onClick={doGenerate} disabled={busy}>{busy ? "جارٍ…" : "Generate"}</button>
+          <a className="btn" href="/api/export">Export ZIP</a>
+          <a className="btn" href="/snapshots/" target="_blank" rel="noopener noreferrer">Open Snapshot</a>
         </div>
         {msg && <div className="note">{msg}</div>}
         {verify && (
@@ -186,6 +205,15 @@ export default function Editor() {
             {verify.glossary_entries > 0 && (
               <span>Glossary: {verify.glossary_entries}</span>
             )}
+            <span>Dir: {verify.rtl_ltr}</span>
+            <span>Idempotent: {verify.idempotency ? <span className="verify-ok">✓</span> : <span className="verify-warn">⚠️</span>}</span>
+          </div>
+        )}
+        {files.length > 0 && (
+          <div className="file-list">
+            <ul>
+              {files.map(f => <li key={f}>{f}</li>)}
+            </ul>
           </div>
         )}
       </div>

--- a/src/lib/schema/io.ts
+++ b/src/lib/schema/io.ts
@@ -19,7 +19,9 @@ export const OutputSchema = z.object({
     eq_before: z.number().int().nonnegative(),
     eq_after: z.number().int().nonnegative(),
     eq_match: z.boolean(),
-    glossary_entries: z.number().int().nonnegative()
+    glossary_entries: z.number().int().nonnegative(),
+    rtl_ltr: z.enum(["rtl", "ltr", "mixed"]),
+    idempotency: z.boolean()
   })
 });
 export type Output = z.infer<typeof OutputSchema>;


### PR DESCRIPTION
## Summary
- show text direction and idempotency in verify results
- list latest snapshot files after generate/export
- add direct links for Export ZIP and Open Snapshot

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: next not found; npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_689de11c21b083218c151d96caa03b13