### PR TITLE
feat: persist language preference

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,7 +15,6 @@
   --gap:12px;
 }
 *{box-sizing:border-box}
-html{direction:rtl}
 body{
   margin:0; font-family: system-ui, -apple-system, Segoe UI, Arial, sans-serif;
   background: radial-gradient(1200px 600px at 70% -10%, #1b2030 0%, var(--bg) 55%);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,20 +1,35 @@
+"use client";
+
 import "./globals.css";
 import type { Metadata } from "next";
 import Script from "next/script";
+import { useEffect, useState } from "react";
 
 export const metadata: Metadata = {
   title: "Qaadi Live",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const [lang, setLang] = useState("ar");
+  const [dir, setDir] = useState<"ltr" | "rtl">("rtl");
+
+  useEffect(() => {
+    try {
+      const l = localStorage.getItem("lang");
+      const d = localStorage.getItem("dir");
+      if (l) setLang(l);
+      if (d === "rtl" || d === "ltr") setDir(d as "rtl" | "ltr");
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = lang;
+    document.documentElement.dir = dir;
+  }, [lang, dir]);
+
   return (
-    <html lang="ar" dir="rtl">
+    <html lang={lang} dir={dir}>
       <head>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `try{var l=localStorage.getItem('lang');if(l)document.documentElement.lang=l;var d=localStorage.getItem('dir');if(d)document.documentElement.dir=d;}catch(e){}`
-          }}
-        />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#111111" />
         <link rel="icon" href="/favicon.png" />

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -25,10 +25,23 @@ export default function Editor() {
     try {
       setOpenaiKey(localStorage.getItem("OPENAI_KEY") || "");
       setDeepseekKey(localStorage.getItem("DEEPSEEK_KEY") || "");
+      const storedLang = localStorage.getItem("lang");
+      if (storedLang) setLang(storedLang as Lang);
     } catch {}
   }, []);
   useEffect(() => { try { localStorage.setItem("OPENAI_KEY", openaiKey); } catch {} }, [openaiKey]);
   useEffect(() => { try { localStorage.setItem("DEEPSEEK_KEY", deepseekKey); } catch {} }, [deepseekKey]);
+  useEffect(() => {
+    try {
+      if (lang) {
+        localStorage.setItem("lang", lang);
+        const d = lang === "ar" || lang === "tr" ? "rtl" : "ltr";
+        localStorage.setItem("dir", d);
+        document.documentElement.lang = lang;
+        document.documentElement.dir = d;
+      }
+    } catch {}
+  }, [lang]);
 
   const headers = useMemo(() => ({
     "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- use language and direction from localStorage-driven state in RootLayout
- drop unconditional RTL rule from global stylesheet
- store language choice in Editor and auto-set text direction

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: next: not found)
- `npm install` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689de11a7a888321b0477726201fa172