### PR TITLE
feat: report storage and kv in health check

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,15 +1,26 @@
 export const runtime = "edge";
 export async function GET() {
-  return new Response(JSON.stringify({
-    env: "OK",
-    policies: { byok: true },
-    build: { tag: process.env.NEXT_PUBLIC_BUILD_TAG ?? "qaadi-fast-track" }
-  }), {
-    headers: {
-      "Content-Type": "application/json",
-      "Cache-Control": "no-store",
-      "X-Content-Type-Options": "nosniff",
-      "Access-Control-Allow-Origin": "*"
+  const storage = process.env.NEXT_PUBLIC_STORAGE ?? "storage unavailable";
+  const kv = process.env.NEXT_PUBLIC_KV ?? "kv unavailable";
+  const capsuleLatest =
+    process.env.NEXT_PUBLIC_CAPSULE_LATEST ?? "capsule information unavailable";
+
+  return new Response(
+    JSON.stringify({
+      env: "OK",
+      policies: { byok: true },
+      build: { tag: process.env.NEXT_PUBLIC_BUILD_TAG ?? "qaadi-fast-track" },
+      storage,
+      kv,
+      capsule: { latest: capsuleLatest }
+    }),
+    {
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+        "Access-Control-Allow-Origin": "*"
+      }
     }
-  });
+  );
 }

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { GET } from '../src/app/api/health/route';
+
+// Ensure the health endpoint exposes additional diagnostic fields.
+test('health endpoint includes storage, kv, and capsule.latest', async () => {
+  const res = await GET();
+  assert.strictEqual(res.status, 200);
+  const body = await res.json();
+  assert.ok('storage' in body);
+  assert.ok('kv' in body);
+  assert.ok(body.capsule && 'latest' in body.capsule);
+});


### PR DESCRIPTION
## Summary
- expose storage, kv and capsule info in `/api/health`
- cover new fields with unit test

## Testing
- `npm test` (fails: Cannot find package 'ts-node')

------
https://chatgpt.com/codex/tasks/task_e_689de9cc30b88321b4677abd6078c734