### PR TITLE
Store export snapshots in public directory

### DIFF
--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -60,7 +60,7 @@ async function saveSnapshot(files: ZipFile[], target: string, lang: string) {
   for (const f of files) {
     const data = typeof f.content === "string" ? Buffer.from(f.content) : Buffer.from(f.content);
     const rel = path.join("snapshots", tsDir, "paper", target, lang, f.path.replace(/^paper\//, ""));
-    const full = path.join(process.cwd(), rel);
+    const full = path.join(process.cwd(), "public", rel);
     await mkdir(path.dirname(full), { recursive: true });
     await writeFile(full, data);
     entries.push({
@@ -72,7 +72,7 @@ async function saveSnapshot(files: ZipFile[], target: string, lang: string) {
     });
   }
 
-  const manifestPath = path.join(process.cwd(), "snapshots", "manifest.json");
+  const manifestPath = path.join(process.cwd(), "public", "snapshots", "manifest.json");
   let manifest: any[] = [];
   try {
     const existing = await readFile(manifestPath, "utf-8");


### PR DESCRIPTION
## Summary
- Persist snapshot files and manifest inside `public/snapshots`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/qaadi-live/node_modules/ts-node/esm')*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_689de9c861788321ad6c7be32faa23df