### PR TITLE
chore: sync theme color

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Qaadi Live",
+  "short_name": "Qaadi",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f1115",
+  "theme_color": "#0f1115",
+  "icons": [
+    {
+      "src": "/favicon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang={lang} dir={dir}>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="theme-color" content="#111111" />
+        <meta name="theme-color" content="#0f1115" />
         <link rel="icon" href="/favicon.png" />
         <link rel="manifest" href="/manifest.webmanifest" />
         <Script id="sw-register" strategy="afterInteractive">


### PR DESCRIPTION
## Summary
- align layout theme-color with manifest settings
- add web manifest with matching theme and background colors

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/esm')*

------
https://chatgpt.com/codex/tasks/task_e_689dee4cfc308321815d68c2677f7297