### PR TITLE
chore: update language codes

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -110,11 +110,10 @@ function buildPrompt(
     | "en"
     | "tr"
     | "fr"
-    | "de"
     | "es"
+    | "de"
     | "ru"
-    | "fa"
-    | "zh"
+    | "zh-Hans"
     | "ja"
     | "other",
   userText: string,
@@ -143,10 +142,8 @@ function buildPrompt(
       return `WIDE/ES: Eres el motor Qaadi. Edita texto español amplio dirigido al artículo (bundle.md). Entrada:\n${userText}${gloss}`;
     if (lang === "ru")
       return `WIDE/RU: Ты движок Qaadi. Редактируй широкий русский текст для статьи (bundle.md). Ввод:\n${userText}${gloss}`;
-    if (lang === "fa")
-      return `WIDE/FA: شما موتور Qaadi هستید. متن فارسی گسترده برای مقاله (bundle.md) را ویرایش کنید. ورودی:\n${userText}${gloss}`;
-    if (lang === "zh")
-      return `WIDE/ZH: 你是 Qaadi 引擎。编辑面向论文的中文长文 (bundle.md)。输入:\n${userText}${gloss}`;
+    if (lang === "zh-Hans")
+      return `WIDE/ZH-HANS: 你是 Qaadi 引擎。编辑面向论文的中文长文 (bundle.md)。输入:\n${userText}${gloss}`;
     if (lang === "ja")
       return `WIDE/JA: あなたは Qaadi エンジンです。論文用の日本語の長文を編集してください (bundle.md)。入力:\n${userText}${gloss}`;
     if (lang === "other")
@@ -162,11 +159,10 @@ function buildPrompt(
       en: "English",
       tr: "Turkish",
       fr: "French",
-      de: "German",
       es: "Spanish",
+      de: "German",
       ru: "Russian",
-      fa: "Persian",
-      zh: "Chinese",
+      "zh-Hans": "Chinese (Simplified)",
       ja: "Japanese"
     };
     const targetNames: Record<string, string> = {

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -15,11 +15,10 @@ type Lang =
   | "en"
   | "tr"
   | "fr"
-  | "de"
   | "es"
+  | "de"
   | "ru"
-  | "fa"
-  | "zh"
+  | "zh-Hans"
   | "ja"
   | "other";
 type ModelSel = "openai" | "deepseek" | "auto";
@@ -216,11 +215,10 @@ export default function Editor() {
             <option value="ar">AR</option>
             <option value="tr">TR</option>
             <option value="fr">FR</option>
-            <option value="de">DE</option>
             <option value="es">ES</option>
+            <option value="de">DE</option>
             <option value="ru">RU</option>
-            <option value="fa">FA</option>
-            <option value="zh">ZH</option>
+            <option value="zh-Hans">ZH-Hans</option>
             <option value="ja">JA</option>
             <option value="other">Other</option>
           </select>

--- a/src/lib/schema/io.ts
+++ b/src/lib/schema/io.ts
@@ -16,11 +16,10 @@ export const InputSchema = z.object({
     "en",
     "tr",
     "fr",
-    "de",
     "es",
+    "de",
     "ru",
-    "fa",
-    "zh",
+    "zh-Hans",
     "ja",
     "other"
   ]),


### PR DESCRIPTION
## Summary
- align language schema with official codes
- sync editor options with updated language list
- handle zh-Hans and drop Persian branch in prompt builder

## Testing
- `npm install --no-progress` (fails: 403 Forbidden - GET https://registry.npmjs.org/ts-node)
- `npm test` (fails: Cannot find module '/workspace/qaadi-live/node_modules/ts-node/esm')

------
https://chatgpt.com/codex/tasks/task_e_689def5234348321bb9f4eab69ff9893