### PR TITLE
feat: add slug support for snapshots

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -157,13 +157,22 @@ export default function Editor() {
 
   async function refreshFiles() {
     try {
+      const slug =
+        typeof window !== "undefined"
+          ? window.location.pathname.split("/").filter(Boolean)[0] ||
+            new URLSearchParams(window.location.search).get("slug") ||
+            "default"
+          : "default";
       const res = await fetch("/snapshots/manifest.json");
       if (!res.ok) { setFiles([]); return; }
       const list = await res.json();
       if (Array.isArray(list) && list.length) {
-        const latest = list.reduce((m:any, c:any) => c.timestamp > m ? c.timestamp : m, "");
-        const fl = list.filter((f:any) => f.timestamp === latest).map((f:any) => f.path);
-        setFiles(fl);
+        const scoped = list.filter((f:any) => f.slug === slug);
+        if (scoped.length) {
+          const latest = scoped.reduce((m:any, c:any) => c.timestamp > m ? c.timestamp : m, "");
+          const fl = scoped.filter((f:any) => f.timestamp === latest).map((f:any) => f.path);
+          setFiles(fl);
+        } else setFiles([]);
       } else setFiles([]);
     } catch { setFiles([]); }
   }


### PR DESCRIPTION
## Summary
- store snapshots under `snapshots/<slug>/<timestamp>` and include slug in manifest entries
- pass request-provided slug to snapshot saving in export API
- fetch latest snapshot for current slug in editor

## Testing
- `npm test` *(fails: Cannot find module 'ts-node')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_689def46bd508321a629d7d3d64971bc