### PR TITLE
Use neutral defaults for language and direction

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,16 +10,29 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const [lang, setLang] = useState("ar");
-  const [dir, setDir] = useState<"ltr" | "rtl">("rtl");
+  const [lang, setLang] = useState(
+    typeof navigator !== "undefined" ? navigator.language.split("-")[0] : ""
+  );
+  const [dir, setDir] = useState<"ltr" | "rtl" | "">(
+    typeof navigator !== "undefined"
+      ? navigator.language.startsWith("ar")
+        ? "rtl"
+        : "ltr"
+      : ""
+  );
 
   useEffect(() => {
     try {
       const l = localStorage.getItem("lang");
       const d = localStorage.getItem("dir");
       if (l) setLang(l);
+      else setLang("en");
       if (d === "rtl" || d === "ltr") setDir(d as "rtl" | "ltr");
-    } catch {}
+      else setDir("ltr");
+    } catch {
+      setLang("en");
+      setDir("ltr");
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Initialize lang/dir from navigator.language and default to English/left-to-right when no saved settings
- Ensure first render updates document attributes accordingly

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/esm')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689def4b3130832190e1345702fb3825