### PR TITLE
feat: store generate output snapshots

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -83,7 +83,8 @@ export default function Editor() {
       setOut(j?.text || "");
       setVerify(j?.checks || null);
       setMsg(`OK • model=${j?.model_used} • in=${j?.tokens_in} • out=${j?.tokens_out} • ${j?.latency_ms}ms`);
-      await refreshFiles();
+      if (Array.isArray(j?.files)) setFiles(j.files);
+      else await refreshFiles();
     } catch (e:any) {
       setMsg(e?.message === "missing_target_lang" ? "يرجى اختيار الهدف واللغة" : `ERROR: ${e?.message || e}`);
       setVerify(null);

--- a/src/lib/schema/io.ts
+++ b/src/lib/schema/io.ts
@@ -50,6 +50,7 @@ export const OutputSchema = z.object({
     glossary_entries: z.number().int().nonnegative(),
     rtl_ltr: z.enum(["rtl", "ltr", "mixed"]),
     idempotency: z.boolean()
-  })
+  }),
+  files: z.array(z.string()).optional()
 });
 export type Output = z.infer<typeof OutputSchema>;


### PR DESCRIPTION
## Summary
- save generated text to snapshot files under `public/snapshots` and update manifest
- add helper to persist snapshots and return saved paths
- surface returned file paths in the editor for immediate display

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ts-node)*
- `npm test` *(fails: Cannot find module '/workspace/qaadi-live/node_modules/ts-node/esm')*

------
https://chatgpt.com/codex/tasks/task_e_689def461444832181be662f88ca3b89