### PR TITLE
Register service worker via Script on load

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,15 +34,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <meta name="theme-color" content="#0f1115" />
         <link rel="icon" href="/favicon.png" />
         <link rel="manifest" href="/manifest.webmanifest" />
-        <Script id="sw-register" strategy="afterInteractive">
-          {`
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/sw.js').catch(() => {});
-      });
-    }
-  `}
-        </Script>
+        <Script
+          id="sw-register"
+          strategy="afterInteractive"
+          onLoad={() => {
+            if ("serviceWorker" in navigator) {
+              navigator.serviceWorker.register("/sw.js").catch(() => {});
+            }
+          }}
+        />
       </head>
       <body>
         <div className="wrapper">{children}</div>


### PR DESCRIPTION
## Summary
- Register service worker using Next.js `Script` component with an `onLoad` handler instead of inline script

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*
- `npm install` *(fails: 403 Forbidden fetching ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_689df1eca5508321aeb11da23a4f8416