### PR TITLE
Specify favicon type and size

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#0f1115" />
-        <link rel="icon" href="/favicon.png" />
+        <link
+          rel="icon"
+          href="/favicon.png"
+          type="image/png"
+          sizes="512x512"
+        />
         <link rel="manifest" href="/manifest.webmanifest" />
         <Script
           id="sw-register"


### PR DESCRIPTION
## Summary
- add explicit PNG type and 512x512 size to favicon link

## Testing
- `npm test` *(fails: Cannot find module '/workspace/qaadi-live/node_modules/ts-node/esm')*


------
https://chatgpt.com/codex/tasks/task_e_689dfa61728883218176b45080a8fecb