### PR TITLE
feat: add snapshot placeholders for bibliography and figures

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -129,7 +129,11 @@ function tsFolder(d = new Date()) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}`;
 }
 
-async function saveSnapshot(files: { path: string; content: string | Uint8Array }[], target: string, lang: string) {
+export async function saveSnapshot(
+  files: { path: string; content: string | Uint8Array }[],
+  target: string,
+  lang: string
+) {
   const now = new Date();
   const tsDir = tsFolder(now);
   const timestamp = now.toISOString();
@@ -144,6 +148,33 @@ async function saveSnapshot(files: { path: string; content: string | Uint8Array 
     entries.push({
       path: rel.replace(/\\/g, "/"),
       sha256: sha256Hex(data),
+      target,
+      lang,
+      timestamp
+    });
+  }
+
+  if (target !== "wide" && target !== "inquiry") {
+    const base = path.join("snapshots", tsDir, "paper", target, lang);
+
+    const relBib = path.join(base, "biblio.bib");
+    const fullBib = path.join(process.cwd(), "public", relBib);
+    await mkdir(path.dirname(fullBib), { recursive: true });
+    await writeFile(fullBib, "");
+    entries.push({
+      path: relBib.replace(/\\/g, "/"),
+      sha256: sha256Hex(""),
+      target,
+      lang,
+      timestamp
+    });
+
+    const relFigs = path.join(base, "figs");
+    const fullFigs = path.join(process.cwd(), "public", relFigs);
+    await mkdir(fullFigs, { recursive: true });
+    entries.push({
+      path: (relFigs + "/").replace(/\\/g, "/"),
+      sha256: sha256Hex(""),
       target,
       lang,
       timestamp

--- a/test/snapshot-placeholder.test.ts
+++ b/test/snapshot-placeholder.test.ts
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { saveSnapshot } from '../src/app/api/generate/route';
+
+function fakeDates() {
+  const realDate = Date;
+  const dates = [
+    new realDate('2024-01-01T00:00:00Z'),
+    new realDate('2024-01-01T00:01:00Z')
+  ];
+  let idx = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).Date = class extends realDate {
+    constructor() { super(); return dates[idx++]; }
+    static now() { return dates[Math.min(idx, dates.length - 1)].getTime(); }
+  } as any;
+  return () => { (global as any).Date = realDate; };
+}
+
+test('placeholder files have stable fingerprints on regeneration', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  const restore = fakeDates();
+  try {
+    await saveSnapshot([{ path: 'paper/draft.tex', content: 'a' }], 'revtex', 'en');
+    await saveSnapshot([{ path: 'paper/draft.tex', content: 'b' }], 'revtex', 'en');
+  } finally {
+    restore();
+    process.chdir(prev);
+  }
+  const manifestPath = path.join(dir, 'public', 'snapshots', 'manifest.json');
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+  const biblio = manifest.filter((e: any) => e.path.endsWith('biblio.bib'));
+  const figs = manifest.filter((e: any) => e.path.endsWith('figs/'));
+  assert.strictEqual(biblio.length, 2);
+  assert.strictEqual(figs.length, 2);
+  assert.strictEqual(new Set(biblio.map((e: any) => e.sha256)).size, 1);
+  assert.strictEqual(new Set(figs.map((e: any) => e.sha256)).size, 1);
+});


### PR DESCRIPTION
## Summary
- create empty `biblio.bib` and `figs/` when saving non-wide/inquiry snapshots
- include placeholder entries in manifest and returned files
- test that placeholder fingerprints stay identical across regenerations

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*


------
https://chatgpt.com/codex/tasks/task_e_689dffced720832192396289f0c5e35b