### PR TITLE
Replace export link with safe button

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -243,9 +243,8 @@ export default function Editor() {
       <div className="card" style={{marginBottom:12}}>
         <div className="actions">
           <button className="btn" onClick={exportCompose} disabled={zipBusy || !target || !lang}>{zipBusy ? "..." : "Export (compose demo)"}</button>
-          <button className="btn btn-primary" onClick={exportOrchestrate} disabled={zipBusy}>{zipBusy ? "..." : "Export (orchestrate)"}</button>
+          <button className="btn btn-primary" onClick={exportOrchestrate} disabled={zipBusy}>{zipBusy ? "..." : "Export ZIP"}</button>
           <button className="btn" onClick={doGenerate} disabled={busy || !target || !lang}>{busy ? "جارٍ…" : "Generate"}</button>
-          <a className="btn" href="/api/export">Export ZIP</a>
           <a className="btn" href="/snapshots/" target="_blank" rel="noopener noreferrer">Open Snapshot</a>
         </div>
         {msg && <div className="note">{msg}</div>}

--- a/test/no-export-get-link.test.ts
+++ b/test/no-export-get-link.test.ts
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Editor from '../src/components/Editor';
+
+test('editor has no direct GET export link', () => {
+  const markup = renderToStaticMarkup(React.createElement(Editor));
+  assert.doesNotMatch(markup, /<a[^>]+href="\/api\/export"/);
+});


### PR DESCRIPTION
## Summary
- replace `/api/export` anchor with button invoking `exportOrchestrate`
- add regression test to ensure no direct export link remains

## Testing
- `npm test` *(fails: cannot find module 'ts-node/esm')*
- `npm install ts-node@10.9.2 --save-dev` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689dffcb92448321b1c36aa095cde186