### PR TITLE
feat: add slug to snapshots

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -97,7 +97,8 @@ export async function POST(req: NextRequest) {
       saved = await saveSnapshot(
         [{ path: `paper/${fileName}`, content: final.text }],
         input.target,
-        input.lang
+        input.lang,
+        input.slug
       );
     } catch (e: any) {
       return new Response(
@@ -129,7 +130,12 @@ function tsFolder(d = new Date()) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}`;
 }
 
-async function saveSnapshot(files: { path: string; content: string | Uint8Array }[], target: string, lang: string) {
+async function saveSnapshot(
+  files: { path: string; content: string | Uint8Array }[],
+  target: string,
+  lang: string,
+  slug: string
+) {
   const now = new Date();
   const tsDir = tsFolder(now);
   const timestamp = now.toISOString();
@@ -137,7 +143,15 @@ async function saveSnapshot(files: { path: string; content: string | Uint8Array 
 
   for (const f of files) {
     const data = typeof f.content === "string" ? Buffer.from(f.content) : Buffer.from(f.content);
-    const rel = path.join("snapshots", tsDir, "paper", target, lang, f.path.replace(/^paper\//, ""));
+    const rel = path.join(
+      "snapshots",
+      slug,
+      tsDir,
+      "paper",
+      target,
+      lang,
+      f.path.replace(/^paper\//, "")
+    );
     const full = path.join(process.cwd(), "public", rel);
     await mkdir(path.dirname(full), { recursive: true });
     await writeFile(full, data);
@@ -146,6 +160,7 @@ async function saveSnapshot(files: { path: string; content: string | Uint8Array 
       sha256: sha256Hex(data),
       target,
       lang,
+      slug,
       timestamp
     });
   }

--- a/src/lib/schema/io.ts
+++ b/src/lib/schema/io.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const InputSchema = z.object({
+  slug: z.string().default("default"),
   target: z.enum([
     "wide",
     "revtex",


### PR DESCRIPTION
## Summary
- include slug field in generated snapshot manifest and paths
- accept slug in generate input schema and forward from editor requests
- scope editor file refresh by slug

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*
- `npm install --no-fund --no-audit` *(fails: 403 Forbidden fetching ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_689dffc9a7fc8321b28c496433abf694