### PR TITLE
refactor: centralize snapshot saving

### DIFF
--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -1,10 +1,9 @@
 import { NextRequest } from "next/server";
 import { makeZip, type ZipFile } from "../../../lib/utils/zip";
 import { runWithFallback } from "../../../lib/providers/router";
-import { mkdir, readFile, writeFile } from "fs/promises";
-import path from "path";
 import crypto from "crypto";
 import { checkIdempotency } from "../../../lib/utils/idempotency";
+import { saveSnapshot } from "../../../lib/utils/snapshot";
 
 export const runtime = "nodejs";
 
@@ -47,43 +46,6 @@ function sha256Hex(data: Uint8Array | string) {
 
 function isoNow() { return new Date().toISOString(); }
 
-function tsFolder(d = new Date()) {
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}`;
-}
-
-async function saveSnapshot(files: ZipFile[], target: string, lang: string, slug: string) {
-  const now = new Date();
-  const tsDir = tsFolder(now);
-  const timestamp = now.toISOString();
-  const entries: any[] = [];
-
-  for (const f of files) {
-    const data = typeof f.content === "string" ? Buffer.from(f.content) : Buffer.from(f.content);
-    const rel = path.join("snapshots", slug, tsDir, "paper", target, lang, f.path.replace(/^paper\//, ""));
-    const full = path.join(process.cwd(), "public", rel);
-    await mkdir(path.dirname(full), { recursive: true });
-    await writeFile(full, data);
-    entries.push({
-      path: rel.replace(/\\/g, "/"),
-      sha256: sha256Hex(data),
-      target,
-      lang,
-      slug,
-      timestamp
-    });
-  }
-
-  const manifestPath = path.join(process.cwd(), "public", "snapshots", "manifest.json");
-  let manifest: any[] = [];
-  try {
-    const existing = await readFile(manifestPath, "utf-8");
-    manifest = JSON.parse(existing);
-  } catch {}
-  manifest.push(...entries);
-  await mkdir(path.dirname(manifestPath), { recursive: true });
-  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-}
 
 function buildTreeFromCompose(payload: any) {
   // EXPECTS:

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -3,9 +3,7 @@ import { InputSchema, OutputSchema } from "../../../lib/schema/io";
 import { runWithFallback } from "../../../lib/providers/router";
 import { freezeText, restoreText, countEquations } from "../../../lib/utils/freeze";
 import { checkIdempotency } from "../../../lib/utils/idempotency";
-import { mkdir, readFile, writeFile } from "fs/promises";
-import path from "path";
-import crypto from "crypto";
+import { saveSnapshot } from "../../../lib/utils/snapshot";
 
 export const runtime = "nodejs";
 
@@ -117,49 +115,6 @@ export async function POST(req: NextRequest) {
   } catch (e:any) {
     return new Response(JSON.stringify({ error: "provider_error", detail: e?.message || String(e) }), { status: 502 });
   }
-}
-
-function sha256Hex(data: Uint8Array | string) {
-  const buf = typeof data === "string" ? Buffer.from(data) : Buffer.from(data);
-  return crypto.createHash("sha256").update(buf).digest("hex");
-}
-
-function tsFolder(d = new Date()) {
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}`;
-}
-
-async function saveSnapshot(files: { path: string; content: string | Uint8Array }[], target: string, lang: string) {
-  const now = new Date();
-  const tsDir = tsFolder(now);
-  const timestamp = now.toISOString();
-  const entries: any[] = [];
-
-  for (const f of files) {
-    const data = typeof f.content === "string" ? Buffer.from(f.content) : Buffer.from(f.content);
-    const rel = path.join("snapshots", tsDir, "paper", target, lang, f.path.replace(/^paper\//, ""));
-    const full = path.join(process.cwd(), "public", rel);
-    await mkdir(path.dirname(full), { recursive: true });
-    await writeFile(full, data);
-    entries.push({
-      path: rel.replace(/\\/g, "/"),
-      sha256: sha256Hex(data),
-      target,
-      lang,
-      timestamp
-    });
-  }
-
-  const manifestPath = path.join(process.cwd(), "public", "snapshots", "manifest.json");
-  let manifest: any[] = [];
-  try {
-    const existing = await readFile(manifestPath, "utf-8");
-    manifest = JSON.parse(existing);
-  } catch {}
-  manifest.push(...entries);
-  await mkdir(path.dirname(manifestPath), { recursive: true });
-  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-  return entries.map((e) => e.path);
 }
 
 function buildPrompt(

--- a/src/lib/utils/snapshot.ts
+++ b/src/lib/utils/snapshot.ts
@@ -1,0 +1,62 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+import crypto from "crypto";
+import type { ZipFile } from "./zip";
+
+function sha256Hex(data: Uint8Array | string) {
+  const buf = typeof data === "string" ? Buffer.from(data) : Buffer.from(data);
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+function tsFolder(d = new Date()) {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}`;
+}
+
+export async function saveSnapshot(
+  files: ZipFile[],
+  target: string,
+  lang: string,
+  slug?: string
+) {
+  const now = new Date();
+  const tsDir = tsFolder(now);
+  const timestamp = now.toISOString();
+  const entries: any[] = [];
+
+  for (const f of files) {
+    const data = typeof f.content === "string" ? Buffer.from(f.content) : Buffer.from(f.content);
+    const rel = path.join(
+      "snapshots",
+      ...(slug ? [slug] : []),
+      tsDir,
+      "paper",
+      target,
+      lang,
+      f.path.replace(/^paper\//, "")
+    );
+    const full = path.join(process.cwd(), "public", rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, data);
+    entries.push({
+      path: rel.replace(/\\/g, "/"),
+      sha256: sha256Hex(data),
+      target,
+      lang,
+      ...(slug ? { slug } : {}),
+      timestamp
+    });
+  }
+
+  const manifestPath = path.join(process.cwd(), "public", "snapshots", "manifest.json");
+  let manifest: any[] = [];
+  try {
+    const existing = await readFile(manifestPath, "utf-8");
+    manifest = JSON.parse(existing);
+  } catch {}
+  manifest.push(...entries);
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  return entries.map((e) => e.path);
+}
+


### PR DESCRIPTION
## Summary
- create shared `saveSnapshot` utility to write snapshot files and update manifest
- reuse snapshot helper in export and generate API routes

## Testing
- `npm test` *(fails: Cannot find module '/workspace/qaadi-live/node_modules/ts-node/esm')*
- `npm install` *(fails: E403 Forbidden - GET https://registry.npmjs.org/ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_689e00d667a08321bf0460eecb02b70b