### PR TITLE
Replace export link with button

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -243,9 +243,8 @@ export default function Editor() {
       <div className="card" style={{marginBottom:12}}>
         <div className="actions">
           <button className="btn" onClick={exportCompose} disabled={zipBusy || !target || !lang}>{zipBusy ? "..." : "Export (compose demo)"}</button>
-          <button className="btn btn-primary" onClick={exportOrchestrate} disabled={zipBusy}>{zipBusy ? "..." : "Export (orchestrate)"}</button>
+          <button className="btn btn-primary" onClick={exportOrchestrate} disabled={zipBusy}>{zipBusy ? "..." : "Export ZIP"}</button>
           <button className="btn" onClick={doGenerate} disabled={busy || !target || !lang}>{busy ? "جارٍ…" : "Generate"}</button>
-          <a className="btn" href="/api/export">Export ZIP</a>
           <a className="btn" href="/snapshots/" target="_blank" rel="noopener noreferrer">Open Snapshot</a>
         </div>
         {msg && <div className="note">{msg}</div>}


### PR DESCRIPTION
## Summary
- remove direct export link and replace with a button invoking the orchestrated export flow

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/esm')*

------
https://chatgpt.com/codex/tasks/task_e_689e00d1c3708321acfbe31a645b3c2a