### PR TITLE
chore: type snapshot manifest entries

### DIFF
--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -5,6 +5,7 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import path from "path";
 import crypto from "crypto";
 import { checkIdempotency } from "../../../lib/utils/idempotency";
+import type { SnapshotEntry } from "../../../lib/utils/snapshot";
 
 export const runtime = "nodejs";
 
@@ -56,7 +57,7 @@ async function saveSnapshot(files: ZipFile[], target: string, lang: string, slug
   const now = new Date();
   const tsDir = tsFolder(now);
   const timestamp = now.toISOString();
-  const entries: any[] = [];
+  const entries: SnapshotEntry[] = [];
 
   for (const f of files) {
     const data = typeof f.content === "string" ? Buffer.from(f.content) : Buffer.from(f.content);
@@ -75,7 +76,7 @@ async function saveSnapshot(files: ZipFile[], target: string, lang: string, slug
   }
 
   const manifestPath = path.join(process.cwd(), "public", "snapshots", "manifest.json");
-  let manifest: any[] = [];
+  let manifest: SnapshotEntry[] = [];
   try {
     const existing = await readFile(manifestPath, "utf-8");
     manifest = JSON.parse(existing);

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -6,6 +6,7 @@ import { checkIdempotency } from "../../../lib/utils/idempotency";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import path from "path";
 import crypto from "crypto";
+import type { SnapshotEntry } from "../../../lib/utils/snapshot";
 
 export const runtime = "nodejs";
 
@@ -147,7 +148,7 @@ export async function saveSnapshot(
   const now = new Date();
   const tsDir = tsFolder(now);
   const timestamp = now.toISOString();
-  const entries: any[] = [];
+  const entries: SnapshotEntry[] = [];
   const covers: string[] = [];
 
   if (target === "inquiry") {
@@ -208,7 +209,7 @@ export async function saveSnapshot(
   }
 
   const manifestPath = path.join(process.cwd(), "public", "snapshots", "manifest.json");
-  let manifest: any[] = [];
+  let manifest: SnapshotEntry[] = [];
   try {
     const existing = await readFile(manifestPath, "utf-8");
     manifest = JSON.parse(existing);

--- a/src/lib/utils/snapshot.ts
+++ b/src/lib/utils/snapshot.ts
@@ -1,0 +1,8 @@
+export interface SnapshotEntry {
+  path: string;
+  sha256: string;
+  target: string;
+  lang: string;
+  timestamp: string;
+  slug?: string;
+}


### PR DESCRIPTION
## Summary
- define SnapshotEntry interface for snapshot metadata
- type snapshot entry and manifest arrays using SnapshotEntry

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*
- `npm install` *(fails: 403 Forbidden retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_689e0648c790832187b092b14975c8e3