### PR TITLE
Filter snapshots by version

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
+import { latestFilesFor } from "../lib/utils/manifest";
 
 type Target =
   | "wide"
@@ -163,16 +164,18 @@ export default function Editor() {
             new URLSearchParams(window.location.search).get("slug") ||
             "default"
           : "default";
+      const v =
+        typeof window !== "undefined"
+          ? window.location.pathname.split("/").filter(Boolean)[1] ||
+            new URLSearchParams(window.location.search).get("v") ||
+            "default"
+          : "default";
       const res = await fetch("/snapshots/manifest.json");
       if (!res.ok) { setFiles([]); return; }
       const list = await res.json();
       if (Array.isArray(list) && list.length) {
-        const scoped = list.filter((f:any) => f.slug === slug);
-        if (scoped.length) {
-          const latest = scoped.reduce((m:any, c:any) => c.timestamp > m ? c.timestamp : m, "");
-          const fl = scoped.filter((f:any) => f.timestamp === latest).map((f:any) => f.path);
-          setFiles(fl);
-        } else setFiles([]);
+        const fl = latestFilesFor(list, slug, v);
+        setFiles(fl);
       } else setFiles([]);
     } catch { setFiles([]); }
   }

--- a/src/lib/utils/manifest.ts
+++ b/src/lib/utils/manifest.ts
@@ -1,0 +1,14 @@
+export interface ManifestEntry {
+  slug: string;
+  v: string;
+  timestamp: string;
+  path: string;
+  [key: string]: any;
+}
+
+export function latestFilesFor(list: ManifestEntry[], slug: string, v: string): string[] {
+  const scoped = list.filter((f) => f.slug === slug && f.v === v);
+  if (!scoped.length) return [];
+  const latest = scoped.reduce((m, c) => (c.timestamp > m ? c.timestamp : m), "");
+  return scoped.filter((f) => f.timestamp === latest).map((f) => f.path);
+}

--- a/test/manifest-filter.test.ts
+++ b/test/manifest-filter.test.ts
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { latestFilesFor, ManifestEntry } from '../src/lib/utils/manifest';
+
+test('returns only files from requested version', () => {
+  const manifest: ManifestEntry[] = [
+    { slug: 'demo', v: 'v1', timestamp: '20240101T000000', path: 'v1/old.md' },
+    { slug: 'demo', v: 'v1', timestamp: '20240102T000000', path: 'v1/newer.md' },
+    { slug: 'demo', v: 'v2', timestamp: '20240103T000000', path: 'v2/only.md' },
+    { slug: 'demo', v: 'v2', timestamp: '20240104T000000', path: 'v2/latest.md' },
+  ];
+  const files = latestFilesFor(manifest, 'demo', 'v2');
+  assert.deepStrictEqual(files, ['v2/latest.md']);
+});


### PR DESCRIPTION
## Summary
- derive `slug` and `v` from the URL when refreshing snapshots
- filter manifest entries by both slug and version to select latest files
- cover multi-version manifests with a new unit test

## Testing
- `npm test` *(fails: Cannot find module '/workspace/qaadi-live/node_modules/ts-node/esm')*


------
https://chatgpt.com/codex/tasks/task_e_689e0622caec8321a8a88034a6570c90