### PR TITLE
Add favicon icons

### DIFF
--- a/public/favicon-16x16.png
+++ b/public/favicon-16x16.png
@@ -1,0 +1,1 @@
+placeholder icon 16x16 (replace with real image in production)

--- a/public/favicon-32x32.png
+++ b/public/favicon-32x32.png
@@ -1,0 +1,1 @@
+placeholder icon 32x32 (replace with real image in production)

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -7,6 +7,16 @@
   "theme_color": "#0f1115",
   "icons": [
     {
+      "src": "/favicon-16x16.png",
+      "sizes": "16x16",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon-32x32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
       "src": "/icon-192.png",
       "sizes": "192x192",
       "type": "image/png"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,9 +47,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <meta name="theme-color" content="#0f1115" />
         <link
           rel="icon"
-          href="/favicon.png"
+          href="/favicon-16x16.png"
           type="image/png"
-          sizes="512x512"
+          sizes="16x16"
+        />
+        <link
+          rel="icon"
+          href="/favicon-32x32.png"
+          type="image/png"
+          sizes="32x32"
         />
         <link rel="manifest" href="/manifest.webmanifest" />
         <Script


### PR DESCRIPTION
## Summary
- add placeholder 16×16 and 32×32 favicon images
- reference new favicons in layout head and manifest

## Testing
- `npm test` *(fails: Cannot find package 'ts-node')*
- `npm ci` *(fails: Missing dependencies in lock file)*

------
https://chatgpt.com/codex/tasks/task_e_689e05346c2483219da08375d1f794f9