### PR TITLE
feat: add slug-based snapshot paths

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -37,6 +37,9 @@ export async function POST(req: NextRequest) {
   try { input = InputSchema.parse(await req.json()); }
   catch { return new Response(JSON.stringify({ error: "bad_input" }), { status: 400 }); }
 
+  const { searchParams } = new URL(req.url);
+  const slug = searchParams.get("slug") ?? "default";
+
   const idemKey = req.headers.get("Idempotency-Key");
   if (idemKey && !checkIdempotency(`generate:${idemKey}`, input)) {
     return new Response(JSON.stringify({ error: "idempotency_conflict" }), { status: 409 });
@@ -107,7 +110,7 @@ export async function POST(req: NextRequest) {
     let saved: string[] = [];
     let covers: string[] = [];
     try {
-      const res = await saveSnapshot(files, input.target, input.lang);
+      const res = await saveSnapshot(files, input.target, input.lang, slug);
       saved = res.files;
       covers = res.covers;
     } catch (e: any) {
@@ -143,7 +146,8 @@ function tsFolder(d = new Date()) {
 export async function saveSnapshot(
   files: { path: string; content: string | Uint8Array }[],
   target: string,
-  lang: string
+  lang: string,
+  slug: string = "default"
 ) {
   const now = new Date();
   const tsDir = tsFolder(now);
@@ -168,7 +172,7 @@ export async function saveSnapshot(
 
   for (const f of files) {
     const data = typeof f.content === "string" ? Buffer.from(f.content) : Buffer.from(f.content);
-    const rel = path.join("snapshots", tsDir, "paper", target, lang, f.path.replace(/^paper\//, ""));
+    const rel = path.join("snapshots", slug, tsDir, "paper", target, lang, f.path.replace(/^paper\//, ""));
     const full = path.join(process.cwd(), "public", rel);
     await mkdir(path.dirname(full), { recursive: true });
     await writeFile(full, data);
@@ -177,12 +181,13 @@ export async function saveSnapshot(
       sha256: sha256Hex(data),
       target,
       lang,
+      slug,
       timestamp
     });
   }
 
   if (target !== "wide" && target !== "inquiry") {
-    const base = path.join("snapshots", tsDir, "paper", target, lang);
+    const base = path.join("snapshots", slug, tsDir, "paper", target, lang);
 
     const relBib = path.join(base, "biblio.bib");
     const fullBib = path.join(process.cwd(), "public", relBib);
@@ -193,6 +198,7 @@ export async function saveSnapshot(
       sha256: sha256Hex(""),
       target,
       lang,
+      slug,
       timestamp
     });
 
@@ -204,6 +210,7 @@ export async function saveSnapshot(
       sha256: sha256Hex(""),
       target,
       lang,
+      slug,
       timestamp
     });
   }


### PR DESCRIPTION
## Summary
- use slug query parameter for snapshot paths in generate route
- track slug in snapshot entries

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/esm')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e0a73b8b08321a095c26eb91548d0