### PR TITLE
chore: resolve merge conflict in generate route

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -3,9 +3,7 @@ import { InputSchema, OutputSchema } from "../../../lib/schema/io";
 import { runWithFallback } from "../../../lib/providers/router";
 import { freezeText, restoreText, countEquations } from "../../../lib/utils/freeze";
 import { checkIdempotency } from "../../../lib/utils/idempotency";
-import { mkdir, readFile, writeFile } from "fs/promises";
-import path from "path";
-import crypto from "crypto";
+import { saveSnapshot } from "../../../lib/utils/snapshot";
 
 export const runtime = "nodejs";
 
@@ -118,96 +116,6 @@ export async function POST(req: NextRequest) {
   } catch (e:any) {
     return new Response(JSON.stringify({ error: "provider_error", detail: e?.message || String(e) }), { status: 502 });
   }
-}
-
-function sha256Hex(data: Uint8Array | string) {
-  const buf = typeof data === "string" ? Buffer.from(data) : Buffer.from(data);
-  return crypto.createHash("sha256").update(buf).digest("hex");
-}
-
-function tsFolder(d = new Date()) {
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}`;
-}
-
-export async function saveSnapshot(
-  files: { path: string; content: string | Uint8Array }[],
-  target: string,
-  lang: string
-) {
-  const now = new Date();
-  const tsDir = tsFolder(now);
-  const timestamp = now.toISOString();
-  const entries: any[] = [];
-
-  if (target === "inquiry") {
-    const covers: Record<string, string> = {};
-    try {
-      const planData = await readFile(path.join(process.cwd(), "paper", "plan.md"));
-      covers.plan = sha256Hex(planData);
-    } catch {}
-    try {
-      const judgeData = await readFile(path.join(process.cwd(), "paper", "judge.json"));
-      covers.judge = sha256Hex(judgeData);
-    } catch {}
-    files.push({
-      path: "paper/inquiry.json",
-      content: JSON.stringify({ covers }, null, 2)
-    });
-  }
-
-  for (const f of files) {
-    const data = typeof f.content === "string" ? Buffer.from(f.content) : Buffer.from(f.content);
-    const rel = path.join("snapshots", tsDir, "paper", target, lang, f.path.replace(/^paper\//, ""));
-    const full = path.join(process.cwd(), "public", rel);
-    await mkdir(path.dirname(full), { recursive: true });
-    await writeFile(full, data);
-    entries.push({
-      path: rel.replace(/\\/g, "/"),
-      sha256: sha256Hex(data),
-      target,
-      lang,
-      timestamp
-    });
-  }
-
-  if (target !== "wide" && target !== "inquiry") {
-    const base = path.join("snapshots", tsDir, "paper", target, lang);
-
-    const relBib = path.join(base, "biblio.bib");
-    const fullBib = path.join(process.cwd(), "public", relBib);
-    await mkdir(path.dirname(fullBib), { recursive: true });
-    await writeFile(fullBib, "");
-    entries.push({
-      path: relBib.replace(/\\/g, "/"),
-      sha256: sha256Hex(""),
-      target,
-      lang,
-      timestamp
-    });
-
-    const relFigs = path.join(base, "figs");
-    const fullFigs = path.join(process.cwd(), "public", relFigs);
-    await mkdir(fullFigs, { recursive: true });
-    entries.push({
-      path: (relFigs + "/").replace(/\\/g, "/"),
-      sha256: sha256Hex(""),
-      target,
-      lang,
-      timestamp
-    });
-  }
-
-  const manifestPath = path.join(process.cwd(), "public", "snapshots", "manifest.json");
-  let manifest: any[] = [];
-  try {
-    const existing = await readFile(manifestPath, "utf-8");
-    manifest = JSON.parse(existing);
-  } catch {}
-  manifest.push(...entries);
-  await mkdir(path.dirname(manifestPath), { recursive: true });
-  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-  return entries.map((e) => e.path);
 }
 
 function buildPrompt(

--- a/src/lib/utils/snapshot.ts
+++ b/src/lib/utils/snapshot.ts
@@ -1,0 +1,103 @@
+import { mkdir, readFile, writeFile } from "fs/promises";
+import path from "path";
+import crypto from "crypto";
+
+function sha256Hex(data: Uint8Array | string) {
+  const buf = typeof data === "string" ? Buffer.from(data) : Buffer.from(data);
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+function tsFolder(d = new Date()) {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}`;
+}
+
+/**
+ * Persist generated files to the public snapshots directory and update the
+ * manifest.
+ *
+ * Each file is written under `public/snapshots/<timestamp>/paper/<target>/<lang>`
+ * and its SHA-256 checksum recorded. A `manifest.json` file at
+ * `public/snapshots/manifest.json` is appended with metadata about every saved
+ * file. The function returns the relative paths of the stored files so callers
+ * can reference them.
+ */
+export async function saveSnapshot(
+  files: { path: string; content: string | Uint8Array }[],
+  target: string,
+  lang: string
+): Promise<string[]> {
+  const now = new Date();
+  const tsDir = tsFolder(now);
+  const timestamp = now.toISOString();
+  const entries: any[] = [];
+
+  if (target === "inquiry") {
+    const covers: Record<string, string> = {};
+    try {
+      const planData = await readFile(path.join(process.cwd(), "paper", "plan.md"));
+      covers.plan = sha256Hex(planData);
+    } catch {}
+    try {
+      const judgeData = await readFile(path.join(process.cwd(), "paper", "judge.json"));
+      covers.judge = sha256Hex(judgeData);
+    } catch {}
+    files.push({
+      path: "paper/inquiry.json",
+      content: JSON.stringify({ covers }, null, 2)
+    });
+  }
+
+  for (const f of files) {
+    const data = typeof f.content === "string" ? Buffer.from(f.content) : Buffer.from(f.content);
+    const rel = path.join("snapshots", tsDir, "paper", target, lang, f.path.replace(/^paper\//, ""));
+    const full = path.join(process.cwd(), "public", rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, data);
+    entries.push({
+      path: rel.replace(/\\/g, "/"),
+      sha256: sha256Hex(data),
+      target,
+      lang,
+      timestamp
+    });
+  }
+
+  if (target !== "wide" && target !== "inquiry") {
+    const base = path.join("snapshots", tsDir, "paper", target, lang);
+
+    const relBib = path.join(base, "biblio.bib");
+    const fullBib = path.join(process.cwd(), "public", relBib);
+    await mkdir(path.dirname(fullBib), { recursive: true });
+    await writeFile(fullBib, "");
+    entries.push({
+      path: relBib.replace(/\\/g, "/"),
+      sha256: sha256Hex(""),
+      target,
+      lang,
+      timestamp
+    });
+
+    const relFigs = path.join(base, "figs");
+    const fullFigs = path.join(process.cwd(), "public", relFigs);
+    await mkdir(fullFigs, { recursive: true });
+    entries.push({
+      path: (relFigs + "/").replace(/\\/g, "/"),
+      sha256: sha256Hex(""),
+      target,
+      lang,
+      timestamp
+    });
+  }
+
+  const manifestPath = path.join(process.cwd(), "public", "snapshots", "manifest.json");
+  let manifest: any[] = [];
+  try {
+    const existing = await readFile(manifestPath, "utf-8");
+    manifest = JSON.parse(existing);
+  } catch {}
+  manifest.push(...entries);
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  return entries.map((e) => e.path);
+}

--- a/test/snapshot-placeholder.test.ts
+++ b/test/snapshot-placeholder.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { readFile } from 'node:fs/promises';
-import { saveSnapshot } from '../src/app/api/generate/route';
+import { saveSnapshot } from '../src/lib/utils/snapshot';
 
 function fakeDates() {
   const realDate = Date;


### PR DESCRIPTION
## Summary
- refactor generate route to import shared snapshot helper
- introduce centralized snapshot utility and update test to reference it
- drop unnecessary re-export from generate route

## Testing
- `git fetch origin` *(fatal: 'origin' does not appear to be a git repository)*
- `git rebase origin/main` *(fatal: invalid upstream 'origin/main')*
- `npm test` *(fails: Cannot find package 'ts-node' imported from /workspace/qaadi-live)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next/server' or its corresponding type declarations)*
- `npm install --no-audit --no-fund` *(hung with MaxListenersExceededWarning)*

------
https://chatgpt.com/codex/tasks/task_e_689e0547e9f08321b59dd3c71d6c710e