### PR TITLE
Use ts-node register for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node --loader ts-node/esm --test test/**/*.ts"
+    "test": "node --test -r ts-node/register test/**/*.ts"
   },
   "dependencies": {
     "next": "14.2.5",


### PR DESCRIPTION
## Summary
- switch test script to run with ts-node/register loader for TypeScript support

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_689e1b4e97488321bc70d6481598479b