### PR TITLE
refactor: rely on snapshot placeholders

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -100,10 +100,6 @@ export async function POST(req: NextRequest) {
         ? "inquiry.md"
         : "draft.tex";
     const files = [{ path: `paper/${fileName}`, content: final.text }];
-    if (fileName === "draft.tex") {
-      files.push({ path: "paper/biblio.bib", content: "" });
-      files.push({ path: "paper/figs/.gitkeep", content: "" });
-    }
     let saved: string[] = [];
     let covers: string[] = [];
     try {


### PR DESCRIPTION
## Summary
- remove manual biblio and figs placeholders in generate API; saveSnapshot now handles them automatically

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm ci` *(fails: package.json and lockfile are out of sync)*

------
https://chatgpt.com/codex/tasks/task_e_689e3005b2988321aac1cbca6085f9ff