### PR TITLE
feat: versioned snapshot handling

### DIFF
--- a/src/app/api/download/zip/route.ts
+++ b/src/app/api/download/zip/route.ts
@@ -65,8 +65,8 @@ export async function GET(req: NextRequest) {
         timestamp: string;
         path: string;
         sha256: string;
-        slug?: string;
-        v?: string;
+        slug: string;
+        v: string;
       }>).filter((e) => e.slug === slug && e.v === v);
       if (snapEntries.length === 0) {
         matrix = [[1]];

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -53,7 +53,7 @@ function tsFolder(d = new Date()) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}_${pad(d.getHours())}${pad(d.getMinutes())}`;
 }
 
-async function saveSnapshot(files: ZipFile[], target: string, lang: string, slug: string) {
+async function saveSnapshot(files: ZipFile[], target: string, lang: string, slug: string, v: string) {
   const safeSlug = sanitizeSlug(slug);
   const now = new Date();
   const tsDir = tsFolder(now);
@@ -72,6 +72,7 @@ async function saveSnapshot(files: ZipFile[], target: string, lang: string, slug
       target,
       lang,
       slug: safeSlug,
+      v,
       timestamp
     });
   }
@@ -180,6 +181,7 @@ export async function POST(req: NextRequest) {
   const target = typeof body?.target === "string" ? body.target : "default";
   const lang = typeof body?.lang === "string" ? body.lang : "en";
   const slug = typeof body?.slug === "string" ? body.slug : "default";
+  const v = typeof body?.v === "string" ? body.v : "default";
 
   // Mode A: raw → same as old behavior (accept ready files[])
   if (mode === "raw") {
@@ -188,7 +190,7 @@ export async function POST(req: NextRequest) {
     if (!files || !files.length) {
       return new Response(JSON.stringify({ error: "no_files" }), { status: 400, headers: headersJSON() });
     }
-    await saveSnapshot(files, target, lang, slug);
+    await saveSnapshot(files, target, lang, slug, v);
     const zip = makeZip(files);
     const shaHex = sha256Hex(zip);
     return new Response(zip, { status: 200, headers: headersZip(name, zip.byteLength, shaHex) });
@@ -200,7 +202,7 @@ export async function POST(req: NextRequest) {
     if (!files.length) {
       return new Response(JSON.stringify({ error: "compose_empty" }), { status: 400, headers: headersJSON() });
     }
-    await saveSnapshot(files, target, lang, slug);
+    await saveSnapshot(files, target, lang, slug, v);
     const zip = makeZip(files);
     const shaHex = sha256Hex(zip);
     return new Response(zip, { status: 200, headers: headersZip(name, zip.byteLength, shaHex) });
@@ -253,7 +255,7 @@ export async function POST(req: NextRequest) {
     };
 
     const { name, files } = buildTreeFromCompose(composePayload);
-    await saveSnapshot(files, target, lang, slug);
+    await saveSnapshot(files, target, lang, slug, v);
     const zip = makeZip(files);
     const shaHex = sha256Hex(zip);
     return new Response(zip, { status: 200, headers: headersZip(name, zip.byteLength, shaHex) });

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -33,9 +33,7 @@ export async function POST(req: NextRequest) {
   let input;
   try { input = InputSchema.parse(await req.json()); }
   catch { return new Response(JSON.stringify({ error: "bad_input" }), { status: 400 }); }
-
-  const { searchParams } = new URL(req.url);
-  const slug = searchParams.get("slug") ?? "default";
+  const { slug, v } = input;
 
   const idemKey = req.headers.get("Idempotency-Key");
   if (idemKey && !checkIdempotency(`generate:${idemKey}`, input)) {
@@ -107,7 +105,7 @@ export async function POST(req: NextRequest) {
     let saved: string[] = [];
     let covers: string[] = [];
     try {
-      const res = await saveSnapshot(files, input.target, input.lang, slug);
+      const res = await saveSnapshot(files, input.target, input.lang, slug, v);
       saved = res.files;
       covers = res.covers;
     } catch (e: any) {

--- a/src/lib/schema/io.ts
+++ b/src/lib/schema/io.ts
@@ -32,7 +32,9 @@ export const InputSchema = z.object({
     .min(256)
     .max(8192)
     .default(2048),
-  text: z.string().min(1)
+  text: z.string().min(1),
+  slug: z.string().default("default"),
+  v: z.string().default("default")
 });
 export type Input = z.infer<typeof InputSchema>;
 

--- a/test/snapshot-placeholder.test.ts
+++ b/test/snapshot-placeholder.test.ts
@@ -27,16 +27,16 @@ test('placeholder files have stable fingerprints on regeneration', async () => {
   process.chdir(dir);
   const restore = fakeDates();
   try {
-    await saveSnapshot([{ path: 'paper/draft.tex', content: 'a' }], 'revtex', 'en');
-    await saveSnapshot([{ path: 'paper/draft.tex', content: 'b' }], 'revtex', 'en');
+    await saveSnapshot([{ path: 'paper/draft.tex', content: 'a' }], 'revtex', 'en', 'demo', 'v1');
+    await saveSnapshot([{ path: 'paper/draft.tex', content: 'b' }], 'revtex', 'en', 'demo', 'v1');
   } finally {
     restore();
     process.chdir(prev);
   }
   const manifestPath = path.join(dir, 'public', 'snapshots', 'manifest.json');
   const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
-  const biblio = manifest.filter((e: any) => e.path.endsWith('biblio.bib'));
-  const figs = manifest.filter((e: any) => e.path.endsWith('figs/'));
+  const biblio = manifest.filter((e: any) => e.path.endsWith('biblio.bib') && e.slug === 'demo' && e.v === 'v1');
+  const figs = manifest.filter((e: any) => e.path.endsWith('figs/') && e.slug === 'demo' && e.v === 'v1');
   assert.strictEqual(biblio.length, 2);
   assert.strictEqual(figs.length, 2);
   assert.strictEqual(new Set(biblio.map((e: any) => e.sha256)).size, 1);


### PR DESCRIPTION
## Summary
- record version identifiers in snapshot entries and manifests
- forward slug and version through Editor and API layers
- adjust tests for slug/version filtering in manifest reads

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install` *(fails: 403 Forbidden retrieving ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_689e300432fc83218f390d3ebd433c83