### PR TITLE
Expose extended health schema

### DIFF
--- a/docs/health.md
+++ b/docs/health.md
@@ -1,0 +1,25 @@
+# Health Endpoint Schema
+
+The `/api/health` endpoint exposes diagnostic information about the running
+service. The JSON response has the following structure:
+
+```json
+{
+  "env": "OK",
+  "policies": {
+    "byok": true,
+    "storage_public_read_capsules": true,
+    "storage_public_read_theory_zips": true
+  },
+  "build": { "tag": "<build-tag>" },
+  "storage": "<storage-state>",
+  "kv": "<kv-state>",
+  "capsule": {
+    "latest": "<capsule-version>",
+    "sha256": "<capsule-checksum>",
+    "ts": "<capsule-timestamp>"
+  }
+}
+```
+
+Each field reflects environment and policy information useful for diagnostics.

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -4,15 +4,23 @@ export async function GET() {
   const kv = process.env.NEXT_PUBLIC_KV ?? "kv unavailable";
   const capsuleLatest =
     process.env.NEXT_PUBLIC_CAPSULE_LATEST ?? "capsule information unavailable";
+  const capsuleSha256 =
+    process.env.NEXT_PUBLIC_CAPSULE_SHA256 ?? "capsule information unavailable";
+  const capsuleTs =
+    process.env.NEXT_PUBLIC_CAPSULE_TS ?? "capsule information unavailable";
 
   return new Response(
     JSON.stringify({
       env: "OK",
-      policies: { byok: true },
+      policies: {
+        byok: true,
+        storage_public_read_capsules: true,
+        storage_public_read_theory_zips: true
+      },
       build: { tag: process.env.NEXT_PUBLIC_BUILD_TAG ?? "qaadi-fast-track" },
       storage,
       kv,
-      capsule: { latest: capsuleLatest }
+      capsule: { latest: capsuleLatest, sha256: capsuleSha256, ts: capsuleTs }
     }),
     {
       headers: {

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -2,12 +2,24 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { GET } from '../src/app/api/health/route';
 
-// Ensure the health endpoint exposes additional diagnostic fields.
-test('health endpoint includes storage, kv, and capsule.latest', async () => {
+// Ensure the health endpoint exposes the complete diagnostic schema.
+test('health endpoint exposes policies, storage, kv, and capsule fields', async () => {
   const res = await GET();
   assert.strictEqual(res.status, 200);
   const body = await res.json();
+
+  assert.deepStrictEqual(body.policies, {
+    byok: true,
+    storage_public_read_capsules: true,
+    storage_public_read_theory_zips: true
+  });
+
   assert.ok('storage' in body);
   assert.ok('kv' in body);
-  assert.ok(body.capsule && 'latest' in body.capsule);
+  assert.ok(
+    body.capsule &&
+      'latest' in body.capsule &&
+      'sha256' in body.capsule &&
+      'ts' in body.capsule
+  );
 });


### PR DESCRIPTION
## Summary
- expose policies `storage_public_read_capsules` and `storage_public_read_theory_zips`
- include capsule `sha256` and `ts` metadata in health endpoint
- document health endpoint response and test for all fields

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_689e36c808d48321bad63d25d54b4c25