### PR TITLE
Require explicit slug and version in requests

### DIFF
--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -180,8 +180,11 @@ export async function POST(req: NextRequest) {
   const mode = (body?.mode ?? "raw") as "raw" | "compose" | "orchestrate";
   const target = typeof body?.target === "string" ? body.target : "default";
   const lang = typeof body?.lang === "string" ? body.lang : "en";
-  const slug = typeof body?.slug === "string" ? body.slug : "default";
-  const v = typeof body?.v === "string" ? body.v : "default";
+  const slug = typeof body?.slug === "string" && body.slug.trim() ? body.slug : null;
+  const v = typeof body?.v === "string" && body.v.trim() ? body.v : null;
+  if (!slug || !v) {
+    return new Response(JSON.stringify({ error: "missing_slug_v" }), { status: 400, headers: headersJSON() });
+  }
 
   // Mode A: raw → same as old behavior (accept ready files[])
   if (mode === "raw") {

--- a/src/lib/schema/io.ts
+++ b/src/lib/schema/io.ts
@@ -33,8 +33,8 @@ export const InputSchema = z.object({
     .max(8192)
     .default(2048),
   text: z.string().min(1),
-  slug: z.string().default("default"),
-  v: z.string().default("default")
+  slug: z.string().min(1),
+  v: z.string().min(1)
 });
 export type Input = z.infer<typeof InputSchema>;
 

--- a/test/editor-disabled.test.ts
+++ b/test/editor-disabled.test.ts
@@ -4,19 +4,21 @@ import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import Editor from '../src/components/Editor';
 
-test('generate and compose export buttons require target and lang', () => {
-  // initial render without target/lang -> buttons disabled
+test('generate and compose export buttons require slug/version, target and lang', () => {
+  // initial render without slug/v/target/lang -> buttons disabled
   const initial = renderToStaticMarkup(React.createElement(Editor));
   assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
   assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
 
-  // render with target and lang preset -> buttons enabled
+  // render with slug, v, target and lang preset -> buttons enabled
   const origUseState = React.useState;
   let calls = 0;
   (React as any).useState = (init: any) => {
     calls++;
-    if (calls === 3) return ['revtex', () => {}]; // target
-    if (calls === 4) return ['en', () => {}]; // lang
+    if (calls === 3) return ['demo', () => {}]; // slug
+    if (calls === 4) return ['v1', () => {}]; // version
+    if (calls === 5) return ['revtex', () => {}]; // target
+    if (calls === 6) return ['en', () => {}]; // lang
     return origUseState(init);
   };
   const withValues = renderToStaticMarkup(React.createElement(Editor));


### PR DESCRIPTION
## Summary
- Require `slug` and `v` fields in Input schema
- Add slug/version inputs in Editor and ensure API calls include them
- Enforce slug/version in export API and update related tests

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install` *(fails: 403 Forbidden for ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_689e36c431e88321989f00d44ea89682