### PR TITLE
Ensure export requires target and language

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -115,6 +115,7 @@ export default function Editor() {
   async function exportOrchestrate() {
     setZipBusy(true); setMsg("");
     try {
+      if (!target || !lang) throw new Error("missing_target_lang");
       const res = await fetch("/api/export", {
         method: "POST",
         headers,
@@ -139,7 +140,7 @@ export default function Editor() {
       setMsg("ZIP جاهز (orchestrate).");
       await refreshFiles();
     } catch (e:any) {
-      setMsg(`EXPORT ERROR: ${e?.message || e}`);
+      setMsg(e?.message === "missing_target_lang" ? "يرجى اختيار الهدف واللغة" : `EXPORT ERROR: ${e?.message || e}`);
     } finally { setZipBusy(false); }
   }
 
@@ -261,7 +262,7 @@ export default function Editor() {
       <div className="card" style={{marginBottom:12}}>
         <div className="actions">
           <button className="btn" onClick={exportCompose} disabled={zipBusy || !target || !lang}>{zipBusy ? "..." : "Export (compose demo)"}</button>
-          <button className="btn btn-primary" onClick={exportOrchestrate} disabled={zipBusy}>{zipBusy ? "..." : "Export ZIP"}</button>
+          <button className="btn btn-primary" onClick={exportOrchestrate} disabled={zipBusy || !target || !lang}>{zipBusy ? "..." : "Export ZIP"}</button>
           <button className="btn" onClick={doGenerate} disabled={busy || !target || !lang}>{busy ? "جارٍ…" : "Generate"}</button>
           <a className="btn" href="/snapshots/" target="_blank" rel="noopener noreferrer">Open Snapshot</a>
         </div>

--- a/test/editor-disabled.test.ts
+++ b/test/editor-disabled.test.ts
@@ -4,10 +4,11 @@ import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import Editor from '../src/components/Editor';
 
-test('generate and compose export buttons require target and lang', () => {
+test('export and generate buttons require target and lang', () => {
   // initial render without target/lang -> buttons disabled
   const initial = renderToStaticMarkup(React.createElement(Editor));
   assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
+  assert.match(initial, /<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
   assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
 
   // render with target and lang preset -> buttons enabled
@@ -23,5 +24,6 @@ test('generate and compose export buttons require target and lang', () => {
   (React as any).useState = origUseState;
 
   assert.doesNotMatch(withValues, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
+  assert.doesNotMatch(withValues, /<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
   assert.doesNotMatch(withValues, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
 });


### PR DESCRIPTION
## Summary
- Disable export ZIP button until target and language are selected
- Validate target and language before exporting, with friendly message
- Test that export and generate buttons remain disabled without selections

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_689e36c24fb083218eaa16d8a66cf656