### PR TITLE
Add PWA icon references and cache them

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -15,6 +15,16 @@
       "src": "/favicon-32x32.png",
       "sizes": "32x32",
       "type": "image/png"
+    },
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
     }
   ]
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,6 +4,8 @@ const OPTIONAL_CORE_ASSETS = [
   "/manifest.webmanifest",
   "/favicon-16x16.png",
   "/favicon-32x32.png",
+  "/icon-192.png",
+  "/icon-512.png",
 ];
 self.addEventListener("install", (e) => {
   e.waitUntil(


### PR DESCRIPTION
## Summary
- reference 192x192 and 512x512 PWA icons in the web manifest
- cache these icon paths in the service worker
- drop binary icon files to keep repository text-only

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_689e36bf3a348321ace9e619e0928ab5