### PR TITLE
Use slug-specific registries and add migration script

### DIFF
--- a/QaadiDB/registry.json
+++ b/QaadiDB/registry.json
@@ -1,5 +1,0 @@
-{
-  "theories": [
-    { "slug": "demo", "latest": "v1.0" }
-  ]
-}

--- a/QaadiDB/theory-demo/registry.json
+++ b/QaadiDB/theory-demo/registry.json
@@ -1,0 +1,4 @@
+{
+  "slug": "demo",
+  "latest": "v1.0"
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node --test -r ts-node/register test/**/*.ts"
+    "test": "node --test -r ts-node/register test/**/*.ts",
+    "migrate-registry": "ts-node scripts/migrate-registry.ts"
   },
   "dependencies": {
     "next": "14.2.5",

--- a/scripts/migrate-registry.ts
+++ b/scripts/migrate-registry.ts
@@ -1,0 +1,27 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+async function main() {
+  const root = process.cwd();
+  const legacyPath = path.join(root, "QaadiDB", "registry.json");
+  let raw: string;
+  try {
+    raw = await fs.readFile(legacyPath, "utf-8");
+  } catch {
+    console.error("legacy registry not found");
+    return;
+  }
+  const data = JSON.parse(raw) as { theories: Array<{ slug: string; latest: string }> };
+  for (const t of data.theories) {
+    const dir = path.join(root, "QaadiDB", `theory-${t.slug}`);
+    await fs.mkdir(dir, { recursive: true });
+    const target = path.join(dir, "registry.json");
+    await fs.writeFile(target, JSON.stringify({ slug: t.slug, latest: t.latest }, null, 2));
+  }
+  await fs.unlink(legacyPath);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/download/zip/route.ts
+++ b/src/app/api/download/zip/route.ts
@@ -49,7 +49,7 @@ export async function GET(req: NextRequest) {
 
   try {
     const root = process.cwd();
-    const regPath = path.join(root, "QaadiDB", "registry.json");
+    const regPath = path.join(root, "QaadiDB", `theory-${slug}`, "registry.json");
     const registry = await readFile(regPath, "utf-8");
     const registrySha = crypto.createHash("sha256").update(registry).digest("hex");
     const canonicalPath = path.join(root, "QaadiDB", `theory-${slug}`, "canonical", v, "canonical.json");
@@ -97,7 +97,7 @@ export async function GET(req: NextRequest) {
       {
         built_at: builtAt,
         sources: [
-          { path: "registry.json", sha256: registrySha },
+          { path: `QaadiDB/theory-${slug}/registry.json`, sha256: registrySha },
           { path: `QaadiDB/theory-${slug}/canonical/${v}/canonical.json`, sha256: canonicalSha }
         ]
       },
@@ -106,7 +106,7 @@ export async function GET(req: NextRequest) {
     );
 
     const files: ZipFile[] = [
-      { path: "registry.json", content: registry },
+      { path: `QaadiDB/theory-${slug}/registry.json`, content: registry },
       { path: `QaadiDB/theory-${slug}/canonical/${v}/canonical.json`, content: canonical },
       { path: "manifest.json", content: manifest },
       { path: "determinism_matrix.json", content: determinism },


### PR DESCRIPTION
## Summary
- move registry files into slug-specific directories
- update download ZIP API to load per-slug registry
- add migration script and npm script to convert legacy registry

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_689e36c630dc83218ae59e07c67e0de5