### PR TITLE
Freeze code blocks during prompt building and merge glossary definitions

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest } from "next/server";
 import { InputSchema, OutputSchema } from "../../../lib/schema/io";
 import { runWithFallback } from "../../../lib/providers/router";
-import { freezeText, restoreText, countEquations } from "../../../lib/utils/freeze";
+import { freezeText, restoreText, countEquations, FrozenText } from "../../../lib/utils/freeze";
 import { checkIdempotency } from "../../../lib/utils/idempotency";
 import { saveSnapshot } from "../../../lib/utils/snapshot";
+import fs from "fs/promises";
+import path from "path";
 
 export const runtime = "nodejs";
 
@@ -46,14 +48,17 @@ export async function POST(req: NextRequest) {
     return new Response(JSON.stringify({ error: "no_keys_provided" }), { status: 400 });
   }
 
-  const frozen = freezeText(input.text);
-  const eqBefore = frozen.equations.length;
-
   const glossary = await loadGlossary(req);
 
-  let prompt;
+  let prompt: string;
+  let frozen: FrozenText;
   try {
-    prompt = buildPrompt(input.target, input.lang, frozen.text, glossary);
+    ({ prompt, frozen } = buildPrompt(
+      input.target,
+      input.lang,
+      input.text,
+      glossary
+    ));
   } catch (e: any) {
     if (e?.message === "unsupported_inquiry_lang") {
       return new Response(
@@ -67,6 +72,8 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  const eqBefore = frozen.equations.length;
+
   try {
     const out = await runWithFallback(
       input.model === "auto" ? "auto" : (input.model as any),
@@ -74,10 +81,15 @@ export async function POST(req: NextRequest) {
       prompt,
       input.max_tokens
     );
-    let text = restoreText(out.text, frozen.equations, frozen.dois);
+    let text = restoreText(out.text, frozen.equations, frozen.dois, frozen.codes);
     const eqAfter = countEquations(text);
     const frozenOut = freezeText(text);
-    const restored = restoreText(frozenOut.text, frozenOut.equations, frozenOut.dois);
+    const restored = restoreText(
+      frozenOut.text,
+      frozenOut.equations,
+      frozenOut.dois,
+      frozenOut.codes
+    );
     const final = OutputSchema.parse({
       ...out,
       text,
@@ -149,7 +161,8 @@ export function buildPrompt(
     | "other",
   userText: string,
   glossary: Record<string, string> | null
-) {
+): { prompt: string; frozen: FrozenText } {
+  const frozen = freezeText(userText);
   const gloss =
     glossary && Object.keys(glossary).length
       ? "\nGlossary:\n" +
@@ -160,45 +173,45 @@ export function buildPrompt(
 
   if (target === "wide") {
     if (lang === "ar")
-      return `WIDE/AR: أنت محرّك Qaadi. حرّر نصًا عربيًا واسعًا موجّهًا للورقة (bundle.md). المدخل:\n${userText}${gloss}`;
+      return { prompt: `WIDE/AR: أنت محرّك Qaadi. حرّر نصًا عربيًا واسعًا موجّهًا للورقة (bundle.md). المدخل:\n${frozen.text}${gloss}`, frozen };
     if (lang === "en")
-      return `WIDE/EN: You are the Qaadi engine. Edit a wide English text intended for the paper (bundle.md). Input:\n${userText}${gloss}`;
+      return { prompt: `WIDE/EN: You are the Qaadi engine. Edit a wide English text intended for the paper (bundle.md). Input:\n${frozen.text}${gloss}`, frozen };
     if (lang === "tr")
-      return `WIDE/TR: Qaadi motorusun. Makale için geniş Türkçe metni düzenle (bundle.md). Girdi:\n${userText}${gloss}`;
+      return { prompt: `WIDE/TR: Qaadi motorusun. Makale için geniş Türkçe metni düzenle (bundle.md). Girdi:\n${frozen.text}${gloss}`, frozen };
     if (lang === "fr")
-      return `WIDE/FR: Tu es le moteur Qaadi. Édite un texte français étendu destiné au papier (bundle.md). Entrée :\n${userText}${gloss}`;
+      return { prompt: `WIDE/FR: Tu es le moteur Qaadi. Édite un texte français étendu destiné au papier (bundle.md). Entrée :\n${frozen.text}${gloss}`, frozen };
     if (lang === "de")
-      return `WIDE/DE: Du bist der Qaadi-Motor. Bearbeite einen ausführlichen deutschen Text für das Papier (bundle.md). Eingabe:\n${userText}${gloss}`;
+      return { prompt: `WIDE/DE: Du bist der Qaadi-Motor. Bearbeite einen ausführlichen deutschen Text für das Papier (bundle.md). Eingabe:\n${frozen.text}${gloss}`, frozen };
     if (lang === "es")
-      return `WIDE/ES: Eres el motor Qaadi. Edita texto español amplio dirigido al artículo (bundle.md). Entrada:\n${userText}${gloss}`;
+      return { prompt: `WIDE/ES: Eres el motor Qaadi. Edita texto español amplio dirigido al artículo (bundle.md). Entrada:\n${frozen.text}${gloss}`, frozen };
     if (lang === "ru")
-      return `WIDE/RU: Ты движок Qaadi. Редактируй широкий русский текст для статьи (bundle.md). Ввод:\n${userText}${gloss}`;
+      return { prompt: `WIDE/RU: Ты движок Qaadi. Редактируй широкий русский текст для статьи (bundle.md). Ввод:\n${frozen.text}${gloss}`, frozen };
     if (lang === "zh-Hans")
-      return `WIDE/ZH-HANS: 你是 Qaadi 引擎。编辑面向论文的中文长文 (bundle.md)。输入:\n${userText}${gloss}`;
+      return { prompt: `WIDE/ZH-HANS: 你是 Qaadi 引擎。编辑面向论文的中文长文 (bundle.md)。输入:\n${frozen.text}${gloss}`, frozen };
     if (lang === "ja")
-      return `WIDE/JA: あなたは Qaadi エンジンです。論文用の日本語の長文を編集してください (bundle.md)。入力:\n${userText}${gloss}`;
+      return { prompt: `WIDE/JA: あなたは Qaadi エンジンです。論文用の日本語の長文を編集してください (bundle.md)。入力:\n${frozen.text}${gloss}`, frozen };
     if (lang === "other")
-      return `WIDE/OTHER: You are the Qaadi engine. Edit a long text in its original language intended for the paper (bundle.md). Input:\n${userText}${gloss}`;
+      return { prompt: `WIDE/OTHER: You are the Qaadi engine. Edit a long text in its original language intended for the paper (bundle.md). Input:\n${frozen.text}${gloss}`, frozen };
   }
   if (target === "inquiry") {
     if (lang === "ar")
-      return `INQUIRY/AR: أنت محرّك Qaadi. أجب على استفسار عربي موجه للورقة (inquiry.md). المدخل:\n${userText}${gloss}`;
+      return { prompt: `INQUIRY/AR: أنت محرّك Qaadi. أجب على استفسار عربي موجه للورقة (inquiry.md). المدخل:\n${frozen.text}${gloss}`, frozen };
     if (lang === "en")
-      return `INQUIRY/EN: You are the Qaadi engine. Answer an English inquiry intended for the paper (inquiry.md). Input:\n${userText}${gloss}`;
+      return { prompt: `INQUIRY/EN: You are the Qaadi engine. Answer an English inquiry intended for the paper (inquiry.md). Input:\n${frozen.text}${gloss}`, frozen };
     if (lang === "tr")
-      return `INQUIRY/TR: Qaadi motorusun. Makale için Türkçe bir soruyu yanıtla (inquiry.md). Girdi:\n${userText}${gloss}`;
+      return { prompt: `INQUIRY/TR: Qaadi motorusun. Makale için Türkçe bir soruyu yanıtla (inquiry.md). Girdi:\n${frozen.text}${gloss}`, frozen };
     if (lang === "fr")
-      return `INQUIRY/FR: Tu es le moteur Qaadi. Réponds à une requête française destinée à l'article (inquiry.md). Entrée :\n${userText}${gloss}`;
+      return { prompt: `INQUIRY/FR: Tu es le moteur Qaadi. Réponds à une requête française destinée à l'article (inquiry.md). Entrée :\n${frozen.text}${gloss}`, frozen };
     if (lang === "de")
-      return `INQUIRY/DE: Du bist der Qaadi-Motor. Beantworte eine deutsche Anfrage für den Artikel (inquiry.md). Eingabe:\n${userText}${gloss}`;
+      return { prompt: `INQUIRY/DE: Du bist der Qaadi-Motor. Beantworte eine deutsche Anfrage für den Artikel (inquiry.md). Eingabe:\n${frozen.text}${gloss}`, frozen };
     if (lang === "es")
-      return `INQUIRY/ES: Eres el motor Qaadi. Responde una consulta en español destinada al artículo (inquiry.md). Entrada:\n${userText}${gloss}`;
+      return { prompt: `INQUIRY/ES: Eres el motor Qaadi. Responde una consulta en español destinada al artículo (inquiry.md). Entrada:\n${frozen.text}${gloss}`, frozen };
     if (lang === "ru")
-      return `INQUIRY/RU: Ты движок Qaadi. Ответь на русский запрос для статьи (inquiry.md). Ввод:\n${userText}${gloss}`;
+      return { prompt: `INQUIRY/RU: Ты движок Qaadi. Ответь на русский запрос для статьи (inquiry.md). Ввод:\n${frozen.text}${gloss}`, frozen };
     if (lang === "zh-Hans")
-      return `INQUIRY/ZH-HANS: 你是 Qaadi 引擎。用中文回答一个面向论文的询问 (inquiry.md)。输入:\n${userText}${gloss}`;
+      return { prompt: `INQUIRY/ZH-HANS: 你是 Qaadi 引擎。用中文回答一个面向论文的询问 (inquiry.md)。输入:\n${frozen.text}${gloss}`, frozen };
     if (lang === "ja")
-      return `INQUIRY/JA: あなたは Qaadi エンジンです。論文用の日本語の問いに答えてください (inquiry.md)。入力:\n${userText}${gloss}`;
+      return { prompt: `INQUIRY/JA: あなたは Qaadi エンジンです。論文用の日本語の問いに答えてください (inquiry.md)。入力:\n${frozen.text}${gloss}`, frozen };
     throw new Error("unsupported_inquiry_lang");
   }
   const templateTargets = new Set(["revtex", "iop", "sn-jnl", "elsevier", "ieee", "arxiv"]);
@@ -227,18 +240,34 @@ export function buildPrompt(
     const tName = targetNames[target];
     if (!langName || !tName)
       throw new Error(`unsupported_target_lang:${target}:${lang}`);
-    return `${target.toUpperCase()}/${lang.toUpperCase()}: Produce LaTeX draft body (no \\documentclass) for ${tName} style in ${langName}. Input:\n${userText}${gloss}`;
+    return {
+      prompt: `${target.toUpperCase()}/${lang.toUpperCase()}: Produce LaTeX draft body (no \\documentclass) for ${tName} style in ${langName}. Input:\n${frozen.text}${gloss}`,
+      frozen
+    };
   }
   throw new Error(`unsupported_target_lang:${target}:${lang}`);
 }
 
 async function loadGlossary(req: NextRequest): Promise<Record<string, string> | null> {
+  const combined: Record<string, string> = {};
+  try {
+    const defsPath = path.join(process.cwd(), "docs", "definitions.json");
+    const data = await fs.readFile(defsPath, "utf8").catch(() => null);
+    if (data) {
+      const j = JSON.parse(data);
+      const g = (j as any)?.Glossary || (j as any)?.glossary;
+      if (g && typeof g === "object") Object.assign(combined, g);
+    }
+  } catch {}
+
   try {
     const url = new URL("/glossary.json", req.url);
     const r = await fetch(url.toString());
-    if (!r.ok) return null;
-    const j = await r.json().catch(() => null);
-    if (j && typeof j === "object") return j as Record<string, string>;
+    if (r.ok) {
+      const j = await r.json().catch(() => null);
+      if (j && typeof j === "object") Object.assign(combined, j as Record<string, string>);
+    }
   } catch {}
-  return null;
+
+  return Object.keys(combined).length ? combined : null;
 }

--- a/src/lib/utils/freeze.ts
+++ b/src/lib/utils/freeze.ts
@@ -2,13 +2,23 @@ export interface FrozenText {
   text: string;
   equations: string[];
   dois: string[];
+  codes: string[];
 }
 
-// Freeze LaTeX equations and DOIs to placeholders
+// Freeze LaTeX equations, code blocks and DOIs to placeholders
 export function freezeText(input: string): FrozenText {
   const equations: string[] = [];
   const dois: string[] = [];
+  const codes: string[] = [];
   let text = input;
+
+  // Code blocks: ```...``` or inline `...`
+  const codeRegex = /```[\s\S]*?```|`[^`\n]+`/g;
+  text = text.replace(codeRegex, (m) => {
+    const id = codes.length;
+    codes.push(m);
+    return `⟦CODE${id}⟧`;
+  });
 
   // LaTeX equations: $$...$$, $...$, \[...\], \(...\)
   const eqRegex = /\$\$[\s\S]*?\$\$|\$[^$]+\$|\\\[[\s\S]*?\\\]|\\\([\s\S]*?\\\)/g;
@@ -26,16 +36,24 @@ export function freezeText(input: string): FrozenText {
     return `⟦DOI${id}⟧`;
   });
 
-  return { text, equations, dois };
+  return { text, equations, dois, codes };
 }
 
-export function restoreText(text: string, equations: string[], dois: string[]): string {
+export function restoreText(
+  text: string,
+  equations: string[],
+  dois: string[],
+  codes: string[]
+): string {
   let out = text;
   equations.forEach((eq, i) => {
     out = out.replace(`⟦EQ${i}⟧`, eq);
   });
   dois.forEach((doi, i) => {
     out = out.replace(`⟦DOI${i}⟧`, doi);
+  });
+  codes.forEach((code, i) => {
+    out = out.replace(`⟦CODE${i}⟧`, code);
   });
   return out;
 }

--- a/test/inquiry.test.ts
+++ b/test/inquiry.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { buildPrompt } from '../src/app/api/generate/route';
 
 test('buildPrompt handles inquiry in English', () => {
-  const prompt = buildPrompt('inquiry', 'en', 'What is the role of Qaadi?', null);
+  const { prompt } = buildPrompt('inquiry', 'en', 'What is the role of Qaadi?', null);
   assert.strictEqual(
     prompt,
     'INQUIRY/EN: You are the Qaadi engine. Answer an English inquiry intended for the paper (inquiry.md). Input:\nWhat is the role of Qaadi?'


### PR DESCRIPTION
## Summary
- Freeze LaTeX, code blocks, and DOIs before sending text to models
- Restore frozen items post-translation and verify equation counts
- Merge glossary definitions from `docs/definitions.json`

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_689f25a96c288321a5f75b942733aa3f