### PR TITLE
feat: visualise judge scores

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import { latestFilesFor } from "../lib/utils/manifest";
+import ScoreCharts from "./ScoreCharts";
 
 type Target =
   | "wide"
@@ -40,6 +41,7 @@ export default function Editor() {
   const [msg, setMsg] = useState<string>("");
   const [verify, setVerify] = useState<null | { eq_before:number; eq_after:number; eq_match:boolean; glossary_entries:number; rtl_ltr:string; idempotency:boolean }>(null);
   const [files, setFiles] = useState<string[]>([]);
+  const [judge, setJudge] = useState<any>(null);
 
   const slug = useMemo(() => {
     if (typeof window !== "undefined") {
@@ -200,6 +202,13 @@ export default function Editor() {
         setFiles(fl);
       } else setFiles([]);
     } catch { setFiles([]); }
+    try {
+      const jr = await fetch("/paper/judge.json");
+      if (jr.ok) {
+        const jj = await jr.json();
+        setJudge(jj);
+      } else setJudge(null);
+    } catch { setJudge(null); }
   }
 
   return (
@@ -287,6 +296,11 @@ export default function Editor() {
             )}
             <span>Dir: {verify.rtl_ltr}</span>
             <span>Idempotent: {verify.idempotency ? <span className="verify-ok">✓</span> : <span className="verify-warn">⚠️</span>}</span>
+          </div>
+        )}
+        {judge?.criteria && (
+          <div className="charts">
+            <ScoreCharts criteria={judge.criteria} />
           </div>
         )}
         {files.length > 0 && (

--- a/src/components/ScoreCharts.tsx
+++ b/src/components/ScoreCharts.tsx
@@ -1,0 +1,112 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+interface Criterion {
+  id: number;
+  name: string;
+  score: number;
+  type?: "internal" | "external";
+  covered?: boolean;
+}
+
+interface Props {
+  criteria: Criterion[];
+}
+
+export default function ScoreCharts({ criteria }: Props) {
+  const barRef = useRef<HTMLCanvasElement | null>(null);
+  const radarRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    let bar: any;
+    let radar: any;
+
+    const load = async () => {
+      if (typeof window === "undefined") return;
+      const w = window as any;
+      if (!w.Chart) {
+        await new Promise((resolve, reject) => {
+          const s = document.createElement("script");
+          s.src = "https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js";
+          s.onload = resolve;
+          s.onerror = reject;
+          document.head.appendChild(s);
+        }).catch(() => {});
+      }
+      const Chart = (window as any).Chart;
+      if (!Chart) return;
+
+      const labels = criteria.map(c => c.name);
+      const scores = criteria.map(c => c.score);
+      const colors = criteria.map(c =>
+        c.covered ? "#16a34a" : c.type === "external" ? "#1d4ed8" : "#dc2626"
+      );
+
+      if (barRef.current) {
+        bar = new Chart(barRef.current, {
+          type: "bar",
+          data: {
+            labels,
+            datasets: [
+              {
+                data: scores,
+                backgroundColor: colors
+              }
+            ]
+          },
+          options: {
+            plugins: { legend: { display: false } },
+            scales: { y: { beginAtZero: true } }
+          }
+        });
+      }
+
+      if (radarRef.current) {
+        radar = new Chart(radarRef.current, {
+          type: "radar",
+          data: {
+            labels,
+            datasets: [
+              {
+                data: scores,
+                backgroundColor: "rgba(59,130,246,0.2)",
+                borderColor: "#3b82f6",
+                pointBackgroundColor: colors
+              }
+            ]
+          },
+          options: {
+            plugins: { legend: { display: false } },
+            scales: { r: { beginAtZero: true } }
+          }
+        });
+      }
+    };
+
+    load();
+    return () => {
+      bar?.destroy?.();
+      radar?.destroy?.();
+    };
+  }, [criteria]);
+
+  return (
+    <div className="score-charts">
+      <div className="legend">
+        <span><span className="box internal" /> داخلي</span>
+        <span><span className="box external" /> خارجي</span>
+        <span><span className="box covered" /> مكتمل</span>
+      </div>
+      <div className="chart-wrapper"><canvas ref={barRef} /></div>
+      <div className="chart-wrapper"><canvas ref={radarRef} /></div>
+      <style jsx>{`
+        .legend { display:flex; gap:12px; margin-bottom:8px; }
+        .box { display:inline-block; width:12px; height:12px; margin-right:4px; }
+        .internal { background:#dc2626; }
+        .external { background:#1d4ed8; }
+        .covered { background:#16a34a; }
+        .chart-wrapper { margin-bottom:16px; }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- fetch judge data after snapshots update
- render QN-21 score bar and radar charts with color legend

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_689f25a7e9e88321a4a564fdcd9e6b7d