### PR TITLE
feat: manage user criteria and merge into judge reports

### DIFF
--- a/src/lib/runJudge.ts
+++ b/src/lib/runJudge.ts
@@ -1,0 +1,19 @@
+import { JudgeReport, JudgeCriterion } from "./schema/report";
+import type { UserCriterion } from "./userCriteria";
+
+/**
+ * Merge base judge report with active user criteria.
+ */
+export function runJudge(base: JudgeReport, userCriteria: UserCriterion[]): JudgeReport {
+  const extra: JudgeCriterion[] = userCriteria.map((c, idx) => ({
+    id: base.criteria.length + idx + 1,
+    name: c.name,
+    score: 0,
+    notes: "user criterion"
+  }));
+  return {
+    ...base,
+    criteria: [...base.criteria, ...extra],
+    score_total: base.score_total + extra.reduce((s, c) => s + c.score, 0)
+  };
+}

--- a/src/lib/userCriteria.ts
+++ b/src/lib/userCriteria.ts
@@ -1,0 +1,55 @@
+export interface UserCriterion {
+  id: string;
+  name: string;
+  enabled: boolean;
+}
+
+const KEY = "qaadi_user_criteria";
+
+function read(): UserCriterion[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as UserCriterion[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(list: UserCriterion[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(KEY, JSON.stringify(list));
+  } catch {}
+}
+
+export function loadUserCriteria() {
+  return read();
+}
+
+export function saveUserCriteria(list: UserCriterion[]) {
+  write(list);
+}
+
+export function upsertCriterion(c: UserCriterion) {
+  const list = read();
+  const idx = list.findIndex(x => x.id === c.id);
+  if (idx >= 0) list[idx] = { ...list[idx], ...c };
+  else list.push(c);
+  write(list);
+  return list;
+}
+
+export function toggleCriterion(id: string) {
+  const list = read();
+  const idx = list.findIndex(x => x.id === id);
+  if (idx >= 0) {
+    list[idx].enabled = !list[idx].enabled;
+    write(list);
+  }
+  return list;
+}
+
+export function getActiveCriteria() {
+  return read().filter(c => c.enabled);
+}


### PR DESCRIPTION
## Summary
- allow storing user-defined criteria in localStorage
- merge active user criteria into judge report during export
- UI to add and toggle user criteria before evaluation

## Testing
- `node --test --loader ts-node/esm test/**/*.ts` *(fails: test code failure)*

------
https://chatgpt.com/codex/tasks/task_e_689f25a44f3c8321a378ca8172fd64e5