### PR TITLE
feat: implement judge and consultant workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node --test -r ts-node/register test/**/*.ts",
+    "test": "node --test --experimental-strip-types test/**/*.ts",
     "migrate-registry": "ts-node scripts/migrate-registry.ts"
   },
   "dependencies": {

--- a/src/lib/utils/review.ts
+++ b/src/lib/utils/review.ts
@@ -1,0 +1,60 @@
+import { writeFile, readFile } from 'fs/promises';
+import path from 'path';
+
+export interface JudgeCriterion {
+  category: 'internal' | 'external';
+  score: number;
+  gap?: string;
+}
+
+export interface JudgeReport {
+  score_total: number;
+  gaps: {
+    internal: string[];
+    external: string[];
+  };
+}
+
+/**
+ * Compute total score and gap table grouped by internal/external.
+ * Results are written to paper/judge.json.
+ */
+export async function runJudge(criteria: JudgeCriterion[]): Promise<JudgeReport> {
+  const score_total = criteria.reduce((sum, c) => sum + c.score, 0);
+  const gaps = { internal: [] as string[], external: [] as string[] };
+  for (const c of criteria) {
+    if (c.gap) {
+      if (c.category === 'external') gaps.external.push(c.gap);
+      else gaps.internal.push(c.gap);
+    }
+  }
+  const report: JudgeReport = { score_total, gaps };
+  const outPath = path.join(process.cwd(), 'paper', 'judge.json');
+  await writeFile(outPath, JSON.stringify(report, null, 2));
+  return report;
+}
+
+/**
+ * Convert gap table into a development plan with priorities.
+ * Gaps from the judge are mapped: internal → P0, external → P1.
+ * A generic polish step is appended as P2.
+ * The resulting Markdown is written to paper/plan.md.
+ */
+export async function runConsultant(): Promise<string> {
+  const judgePath = path.join(process.cwd(), 'paper', 'judge.json');
+  const raw = await readFile(judgePath, 'utf-8');
+  const data: JudgeReport = JSON.parse(raw);
+  const lines: string[] = [];
+  for (const g of data.gaps.internal) {
+    lines.push(`- [P0] ${g}`);
+  }
+  for (const g of data.gaps.external) {
+    lines.push(`- [P1] ${g}`);
+  }
+  lines.push('- [P2] polish and review');
+  const plan = lines.join('\n');
+  const planPath = path.join(process.cwd(), 'paper', 'plan.md');
+  await writeFile(planPath, plan);
+  return plan;
+}
+

--- a/src/lib/utils/snapshot.ts
+++ b/src/lib/utils/snapshot.ts
@@ -48,10 +48,12 @@ export async function saveSnapshot(
     try {
       const planData = await readFile(path.join(process.cwd(), "paper", "plan.md"));
       covers.push(sha256Hex(planData));
+      files.push({ path: "paper/plan.md", content: planData });
     } catch {}
     try {
       const judgeData = await readFile(path.join(process.cwd(), "paper", "judge.json"));
       covers.push(sha256Hex(judgeData));
+      files.push({ path: "paper/judge.json", content: judgeData });
     } catch {}
     files.push({
       path: "paper/inquiry.json",

--- a/test/judge-consultant.test.ts
+++ b/test/judge-consultant.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { mkdtemp, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { runJudge, runConsultant } from '../src/lib/utils/review.ts';
+import { saveSnapshot } from '../src/lib/utils/snapshot.ts';
+
+test('judge and consultant workflow saves artifacts', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  try {
+    await mkdir('paper', { recursive: true });
+    await runJudge([
+      { category: 'internal', score: 3, gap: 'Missing references' },
+      { category: 'external', score: 2, gap: 'Need experiments' },
+      { category: 'internal', score: 5 }
+    ]);
+    await runConsultant();
+    const judge = JSON.parse(await readFile(path.join('paper', 'judge.json'), 'utf-8'));
+    assert.strictEqual(judge.score_total, 10);
+    assert.deepStrictEqual(judge.gaps, {
+      internal: ['Missing references'],
+      external: ['Need experiments']
+    });
+    const plan = await readFile(path.join('paper', 'plan.md'), 'utf-8');
+    assert(plan.includes('[P0] Missing references'));
+    assert(plan.includes('[P1] Need experiments'));
+    assert(plan.includes('[P2]'));
+    await saveSnapshot([
+      { path: 'paper/inquiry.md', content: 'hello' }
+    ], 'inquiry', 'en', 'demo', 'v1');
+    const manifestPath = path.join('public', 'snapshots', 'manifest.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+    const paths = manifest.map((e: any) => e.path);
+    assert(paths.some((p: string) => p.endsWith('/plan.md')));
+    assert(paths.some((p: string) => p.endsWith('/judge.json')));
+  } finally {
+    process.chdir(prev);
+  }
+});


### PR DESCRIPTION
## Summary
- add runJudge to compute total score and gap table, emitting judge.json
- add runConsultant to produce prioritized plan.md from judge gaps
- persist plan.md and judge.json when snapshotting inquiry results
- switch test runner to node's strip-types mode

## Testing
- `node --test --experimental-strip-types test/judge-consultant.test.ts`
- `npm test` *(fails: Cannot find module '/workspace/qaadi-live/src/app/api/download/zip/route', missing packages like react)*

------
https://chatgpt.com/codex/tasks/task_e_689f25a28a48832193f6158adb287215