### PR TITLE
Add worker roles and orchestrator pipeline

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -4,6 +4,10 @@ import { runWithFallback } from "../../../lib/providers/router";
 import { freezeText, restoreText, countEquations } from "../../../lib/utils/freeze";
 import { checkIdempotency } from "../../../lib/utils/idempotency";
 import { saveSnapshot } from "../../../lib/utils/snapshot";
+import { runSecretary, SecretaryInput } from "../../../lib/workers/secretary";
+import { runJudge } from "../../../lib/workers/judge";
+import { runConsultant } from "../../../lib/workers/consultant";
+import { runJournalist } from "../../../lib/workers/journalist";
 
 export const runtime = "nodejs";
 
@@ -241,4 +245,15 @@ async function loadGlossary(req: NextRequest): Promise<Record<string, string> | 
     if (j && typeof j === "object") return j as Record<string, string>;
   } catch {}
   return null;
+}
+
+/**
+ * Orchestrates all worker roles sequentially.
+ */
+export function orchestrate(input: SecretaryInput) {
+  const audit = runSecretary(input);
+  const report = runJudge(audit);
+  const plan = runConsultant(audit, report);
+  const summary = runJournalist(plan);
+  return { audit, report, plan, summary };
 }

--- a/src/lib/workers/consultant.ts
+++ b/src/lib/workers/consultant.ts
@@ -1,0 +1,18 @@
+import { SecretaryResult } from "./secretary";
+import { JudgeReport } from "./judge";
+
+/**
+ * Consultant merges the secretary's issues and judge's report into an action plan.
+ */
+export function runConsultant(audit: SecretaryResult, report: JudgeReport): string {
+  const lines: string[] = [];
+  if (audit.issues.length) {
+    lines.push("Resolve issues:");
+    for (const i of audit.issues) lines.push(`- ${i}`);
+  } else {
+    lines.push("No outstanding issues");
+  }
+  lines.push(`Current score: ${report.scoreTotal}`);
+  return lines.join("\n");
+}
+

--- a/src/lib/workers/journalist.ts
+++ b/src/lib/workers/journalist.ts
@@ -1,0 +1,7 @@
+/**
+ * Journalist creates a short publication-ready summary based on the consultant's plan.
+ */
+export function runJournalist(plan: string): string {
+  return `Summary: ${plan.replace(/\n/g, ' ')}`;
+}
+

--- a/src/lib/workers/judge.ts
+++ b/src/lib/workers/judge.ts
@@ -1,0 +1,18 @@
+import { SecretaryResult } from "./secretary";
+
+export interface JudgeReport {
+  scoreTotal: number;
+  notes: string[];
+}
+
+/**
+ * Judge evaluates the secretary's audit and assigns a score.
+ */
+export function runJudge(audit: SecretaryResult): JudgeReport {
+  const penalties = audit.issues.length * 10;
+  const scoreTotal = Math.max(0, 100 - penalties);
+  const notes = audit.issues.map((i) => `Issue detected: ${i}`);
+  if (!notes.length) notes.push("All clear");
+  return { scoreTotal, notes };
+}
+

--- a/src/lib/workers/lead.ts
+++ b/src/lib/workers/lead.ts
@@ -1,0 +1,18 @@
+import { SecretaryResult } from "./secretary";
+import { JudgeReport } from "./judge";
+
+export interface LeadSummary {
+  audit: SecretaryResult;
+  report: JudgeReport;
+  plan: string;
+  summary: string;
+}
+
+/**
+ * Lead produces a combined summary of all stages.
+ */
+export function runLead(audit: SecretaryResult, report: JudgeReport, plan: string): LeadSummary {
+  const summary = `Ready: ${audit.readyPercent}%, Score: ${report.scoreTotal}`;
+  return { audit, report, plan, summary };
+}
+

--- a/src/lib/workers/secretary.ts
+++ b/src/lib/workers/secretary.ts
@@ -1,0 +1,28 @@
+import { mergeQ21Fields } from "../q21";
+
+export interface SecretaryInput {
+  text: string;
+  units?: string;
+  figure?: string;
+}
+
+export interface SecretaryResult {
+  readyPercent: number;
+  issues: string[];
+  dimensional?: string;
+  diagram?: string;
+}
+
+/**
+ * Runs the secretary stage. It enriches the input using Q21 maps
+ * and performs a very lightweight audit on the submission.
+ */
+export function runSecretary(input: SecretaryInput): SecretaryResult {
+  const merged = mergeQ21Fields({ units: input.units, figure: input.figure });
+  const issues: string[] = [];
+  if (!merged.dimensional) issues.push("missing_units");
+  if (!merged.diagram) issues.push("missing_figure");
+  const readyPercent = 100 - issues.length * 50;
+  return { readyPercent, issues, ...merged };
+}
+


### PR DESCRIPTION
## Summary
- add Secretary, Judge, Consultant, Lead, and Journalist worker modules
- orchestrate new worker roles sequentially through a helper in generate route
- expose pipeline-ready orchestrator interface for future integrations

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install` *(fails: 403 Forbidden for ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_689f25a1c3588321a7b51abc0297c41a