### PR TITLE
feat: add QN21 evaluation API

### DIFF
--- a/docs/q21.md
+++ b/docs/q21.md
@@ -1,25 +1,38 @@
-# Q21 Standard
+# QN21 Evaluation
 
-Q21 defines a lightweight mapping between raw data and canonical labels. It is
-used to normalize units and figure types before reports are generated.
+The QN21 standard defines twenty‑one quality criteria. Each criterion is
+identified by a short `code`, marked as either **internal** or **external**, and
+assigned a `weight` that contributes to the final score. The current project
+uses a uniform weight of `1` for all criteria.
 
-## Maps
+| Code | Type | Weight | Description |
+| ---- | ----- | ------ | ----------- |
+| I1 | internal | 1 | Clear objectives |
+| I2 | internal | 1 | Logical structure |
+| I3 | internal | 1 | Evidence of planning |
+| I4 | internal | 1 | Resource allocation |
+| I5 | internal | 1 | Defined responsibilities |
+| I6 | internal | 1 | Monitoring mechanisms |
+| I7 | internal | 1 | Risk assessment |
+| I8 | internal | 1 | Stakeholder mapping |
+| I9 | internal | 1 | Training program |
+| I10 | internal | 1 | Documentation |
+| E1 | external | 1 | Public transparency |
+| E2 | external | 1 | Accessibility |
+| E3 | external | 1 | Community feedback |
+| E4 | external | 1 | Regulatory compliance |
+| E5 | external | 1 | Performance reporting |
+| E6 | external | 1 | Environmental impact |
+| E7 | external | 1 | Data privacy |
+| E8 | external | 1 | User satisfaction |
+| E9 | external | 1 | Interoperability |
+| E10 | external | 1 | Security posture |
+| E11 | external | 1 | Community engagement |
 
-- **units → dimensional** – convert unit symbols into dimensional categories.
-- **figures → diagrams** – convert figure keywords into diagram styles.
+## Scoring
 
-Both maps live in `src/lib/q21.ts` and can be imported individually or through
-the `Q21` object.
+The `evaluateQN21(text)` helper scans the supplied text for each criterion's
+`code` (case insensitive). When a code is found, the criterion receives its full
+`weight`; otherwise the score is `0`. The `gap` is calculated as
+`weight - score`, indicating how many points remain to fulfill the criterion.
 
-## Usage
-
-```ts
-import { unitsToDimensional, mergeQ21Fields } from "@/lib/q21";
-
-const report = { units: "m", figure: "bar", value: 42 };
-const merged = mergeQ21Fields(report);
-// merged.dimensional === "length" and merged.diagram === "bar diagram"
-```
-
-The `mergeQ21Fields` helper demonstrates how Q21 data can be merged into report
-structures so that downstream consumers receive normalized fields.

--- a/src/lib/q21.ts
+++ b/src/lib/q21.ts
@@ -1,47 +1,57 @@
-export interface Q21Maps {
-  /** Map from unit symbols to their dimensional categories */
-  unitsToDimensional: Record<string, string>;
-  /** Map from figure keywords to diagram styles */
-  figuresToDiagrams: Record<string, string>;
+export interface QN21Criterion {
+  /** Short identifier for the criterion. */
+  code: string;
+  /** Whether the criterion is internal or external to the organization. */
+  type: "internal" | "external";
+  /** Weight of the criterion when calculating the total score. */
+  weight: number;
+  /** Human readable description of the criterion. */
+  description: string;
 }
 
-export const unitsToDimensional: Record<string, string> = {
-  m: "length",
-  s: "time",
-  kg: "mass",
-  A: "electric current",
-  K: "temperature",
-  mol: "amount of substance",
-  cd: "luminous intensity",
-};
+export const QN21_CRITERIA: QN21Criterion[] = [
+  { code: "I1", type: "internal", weight: 1, description: "Clear objectives" },
+  { code: "I2", type: "internal", weight: 1, description: "Logical structure" },
+  { code: "I3", type: "internal", weight: 1, description: "Evidence of planning" },
+  { code: "I4", type: "internal", weight: 1, description: "Resource allocation" },
+  { code: "I5", type: "internal", weight: 1, description: "Defined responsibilities" },
+  { code: "I6", type: "internal", weight: 1, description: "Monitoring mechanisms" },
+  { code: "I7", type: "internal", weight: 1, description: "Risk assessment" },
+  { code: "I8", type: "internal", weight: 1, description: "Stakeholder mapping" },
+  { code: "I9", type: "internal", weight: 1, description: "Training program" },
+  { code: "I10", type: "internal", weight: 1, description: "Documentation" },
+  { code: "E1", type: "external", weight: 1, description: "Public transparency" },
+  { code: "E2", type: "external", weight: 1, description: "Accessibility" },
+  { code: "E3", type: "external", weight: 1, description: "Community feedback" },
+  { code: "E4", type: "external", weight: 1, description: "Regulatory compliance" },
+  { code: "E5", type: "external", weight: 1, description: "Performance reporting" },
+  { code: "E6", type: "external", weight: 1, description: "Environmental impact" },
+  { code: "E7", type: "external", weight: 1, description: "Data privacy" },
+  { code: "E8", type: "external", weight: 1, description: "User satisfaction" },
+  { code: "E9", type: "external", weight: 1, description: "Interoperability" },
+  { code: "E10", type: "external", weight: 1, description: "Security posture" },
+  { code: "E11", type: "external", weight: 1, description: "Community engagement" },
+];
 
-export const figuresToDiagrams: Record<string, string> = {
-  bar: "bar diagram",
-  line: "line diagram",
-  pie: "pie diagram",
-};
+export interface QN21Result extends QN21Criterion {
+  /** Score obtained for the criterion. */
+  score: number;
+  /** Remaining points to reach the full weight of the criterion. */
+  gap: number;
+}
 
 /**
- * Central access point for Q21 standard mappings.
- */
-export const Q21: Q21Maps = {
-  unitsToDimensional,
-  figuresToDiagrams,
-};
-
-/**
- * Helper to merge Q21 fields into a report-like object.
+ * Evaluate text against the QN21 criteria.
  *
- * Example:
- * ```ts
- * const merged = mergeQ21Fields({ units: "m", figure: "bar" });
- * // => { units: "m", figure: "bar", dimensional: "length", diagram: "bar diagram" }
- * ```
+ * The evaluation is keyword based: if a criterion code appears within the
+ * provided text (case insensitive) the full weight is awarded. Otherwise the
+ * score is zero. The `gap` field expresses the missing weight.
  */
-export function mergeQ21Fields<T extends { units?: string; figure?: string }>(input: T) {
-  return {
-    ...input,
-    dimensional: input.units ? unitsToDimensional[input.units] : undefined,
-    diagram: input.figure ? figuresToDiagrams[input.figure] : undefined,
-  };
+export function evaluateQN21(text: string): QN21Result[] {
+  const lower = text.toLowerCase();
+  return QN21_CRITERIA.map((c) => {
+    const score = lower.includes(c.code.toLowerCase()) ? c.weight : 0;
+    return { ...c, score, gap: c.weight - score };
+  });
 }
+

--- a/test/q21.test.ts
+++ b/test/q21.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { evaluateQN21, QN21_CRITERIA } from '../src/lib/q21';
+
+test('evaluateQN21 returns scores and gaps for all criteria', () => {
+  const text = 'I1 E3';
+  const result = evaluateQN21(text);
+
+  assert.strictEqual(result.length, QN21_CRITERIA.length);
+
+  const i1 = result.find((r) => r.code === 'I1');
+  assert.ok(i1);
+  assert.strictEqual(i1?.score, 1);
+  assert.strictEqual(i1?.gap, 0);
+
+  const e3 = result.find((r) => r.code === 'E3');
+  assert.ok(e3);
+  assert.strictEqual(e3?.score, 1);
+
+  const i2 = result.find((r) => r.code === 'I2');
+  assert.ok(i2);
+  assert.strictEqual(i2?.score, 0);
+  assert.strictEqual(i2?.gap, 1);
+});
+


### PR DESCRIPTION
## Summary
- replace placeholder Q21 maps with full list of 21 weighted criteria
- add evaluateQN21() helper to score text against all criteria
- document criteria weights and scoring rules

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_689f25a0a3ec8321967dc4ee00ce16e9