### PR TITLE
Add QN21 summary with judge classification

### DIFF
--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -110,7 +110,7 @@ async function saveSnapshot(files: ZipFile[], target: string, lang: string, slug
   await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 }
 
-function buildTreeFromCompose(payload: any) {
+async function buildTreeFromCompose(payload: any) {
   // EXPECTS:
   // {
   //   name?: "qaadi_export.zip",
@@ -156,10 +156,27 @@ function buildTreeFromCompose(payload: any) {
 
   // 30_judge_report.json
   if (payload?.judge?.report !== undefined) {
+    const report = payload.judge.report;
+    let percentage = 0;
+    let classification: "accepted" | "needs_improvement" | "weak" = "weak";
+    if (Array.isArray(report?.criteria) && typeof report?.score_total === "number") {
+      const max = report.criteria.length * 10;
+      percentage = max > 0 ? (report.score_total / max) * 100 : 0;
+      if (percentage >= 80) classification = "accepted";
+      else if (percentage >= 60) classification = "needs_improvement";
+    }
+    const enriched = { ...report, percentage, classification };
     files.push({
       path: "paper/30_judge_report.json",
-      content: JSON.stringify(payload.judge.report, null, 2)
+      content: JSON.stringify(enriched, null, 2)
     });
+    try {
+      const root = process.cwd();
+      await mkdir(path.join(root, "paper"), { recursive: true });
+      await writeFile(path.join(root, "paper", "judge.json"), JSON.stringify(enriched, null, 2));
+      await mkdir(path.join(root, "public", "paper"), { recursive: true });
+      await writeFile(path.join(root, "public", "paper", "judge.json"), JSON.stringify(enriched, null, 2));
+    } catch {}
   }
 
   // 40_consultant_plan.md
@@ -220,7 +237,7 @@ export async function POST(req: NextRequest) {
 
   // Mode B: compose → client provides unit outputs; server builds canonical tree
   if (mode === "compose") {
-    const { name, files } = buildTreeFromCompose(body);
+    const { name, files } = await buildTreeFromCompose(body);
     if (!files.length) {
       return new Response(JSON.stringify({ error: "compose_empty" }), { status: 400, headers: headersJSON() });
     }
@@ -276,7 +293,7 @@ export async function POST(req: NextRequest) {
       meta: { model: selection, max_tokens }
     };
 
-    const { name, files } = buildTreeFromCompose(composePayload);
+    const { name, files } = await buildTreeFromCompose(composePayload);
     await saveSnapshot(files, target, lang, slug, v);
     const zip = makeZip(files);
     const shaHex = sha256Hex(zip);

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -298,9 +298,16 @@ export default function Editor() {
             <span>Idempotent: {verify.idempotency ? <span className="verify-ok">✓</span> : <span className="verify-warn">⚠️</span>}</span>
           </div>
         )}
-        {judge?.criteria && (
+        {judge && (
           <div className="charts">
-            <ScoreCharts criteria={judge.criteria} />
+            {typeof judge.percentage === "number" && judge.classification && (
+              <div className="judge-summary" style={{marginBottom:8}}>
+                {judge.classification} • {judge.percentage.toFixed(1)}%
+              </div>
+            )}
+            {judge.criteria && (
+              <ScoreCharts criteria={judge.criteria} />
+            )}
           </div>
         )}
         {files.length > 0 && (

--- a/src/lib/q21.ts
+++ b/src/lib/q21.ts
@@ -55,3 +55,31 @@ export function evaluateQN21(text: string): QN21Result[] {
   });
 }
 
+export interface QN21Summary {
+  /** Total points obtained across all criteria. */
+  total: number;
+  /** Maximum obtainable points. */
+  max: number;
+  /** Percentage of points obtained (0-100). */
+  percentage: number;
+  /** Classification based on the percentage. */
+  classification: "accepted" | "needs_improvement" | "weak";
+}
+
+/**
+ * Summarize an array of QN21 results into total score, percentage, and
+ * classification. The classification thresholds are:
+ * - accepted: ≥80%
+ * - needs_improvement: 60–79%
+ * - weak: <60%
+ */
+export function summarizeQN21(results: QN21Result[]): QN21Summary {
+  const total = results.reduce((sum, r) => sum + r.score, 0);
+  const max = results.reduce((sum, r) => sum + r.weight, 0);
+  const percentage = max === 0 ? 0 : (total / max) * 100;
+  let classification: QN21Summary["classification"] = "weak";
+  if (percentage >= 80) classification = "accepted";
+  else if (percentage >= 60) classification = "needs_improvement";
+  return { total, max, percentage, classification };
+}
+

--- a/src/lib/schema/report.ts
+++ b/src/lib/schema/report.ts
@@ -10,7 +10,9 @@ export const JudgeCriterionSchema = z.object({
 export const JudgeReportSchema = z.object({
   score_total: z.number().min(0).max(200),
   criteria: z.array(JudgeCriterionSchema),
-  notes: z.string().optional()
+  notes: z.string().optional(),
+  percentage: z.number().min(0).max(100),
+  classification: z.enum(["accepted", "needs_improvement", "weak"])
 });
 
 export type JudgeCriterion = z.infer<typeof JudgeCriterionSchema>;

--- a/test/q21.test.ts
+++ b/test/q21.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 
-import { evaluateQN21, QN21_CRITERIA } from '../src/lib/q21';
+import { evaluateQN21, QN21_CRITERIA, summarizeQN21 } from '../src/lib/q21';
 
 test('evaluateQN21 returns scores and gaps for all criteria', () => {
   const text = 'I1 E3';
@@ -22,5 +22,15 @@ test('evaluateQN21 returns scores and gaps for all criteria', () => {
   assert.ok(i2);
   assert.strictEqual(i2?.score, 0);
   assert.strictEqual(i2?.gap, 1);
+});
+
+test('summarizeQN21 computes percentage and classification', () => {
+  const text = QN21_CRITERIA.slice(0, 17).map(c => c.code).join(' ');
+  const result = evaluateQN21(text);
+  const summary = summarizeQN21(result);
+  assert.strictEqual(summary.total, 17);
+  assert.strictEqual(summary.max, QN21_CRITERIA.length);
+  assert.ok(summary.percentage > 80);
+  assert.strictEqual(summary.classification, 'accepted');
 });
 


### PR DESCRIPTION
## Summary
- summarize QN21 results into total points, percentage, and classification
- include percentage and classification in judge report and expose via API/UI
- display judge rating in editor and test QN21 summary logic

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_689f4b7ffd688321a67fe2d28297929e