### PR TITLE
feat: generate inquiry questions with covers

### DIFF
--- a/src/app/api/inquiry/route.ts
+++ b/src/app/api/inquiry/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { generateInquiryFromPlan, Lang } from "../../../lib/utils/inquiry";
+import { saveSnapshot } from "../../../lib/utils/snapshot";
+import { readFile } from "fs/promises";
+import path from "path";
+
+export const runtime = "nodejs";
+
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "X-Content-Type-Options": "nosniff",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type"
+    }
+  });
+}
+
+const InputSchema = z.object({
+  lang: z.enum(["ar","en","tr","fr","es","de","ru","zh-Hans","ja","other"]),
+  plan: z.string().optional(),
+  slug: z.string().default("default"),
+  v: z.string().default("default")
+});
+
+export async function POST(req: NextRequest) {
+  let body;
+  try { body = await req.json(); }
+  catch { return new Response(JSON.stringify({ error: "bad_input" }), { status: 400 }); }
+
+  let input;
+  try { input = InputSchema.parse(body); }
+  catch { return new Response(JSON.stringify({ error: "bad_input" }), { status: 400 }); }
+
+  let planText = input.plan;
+  if (!planText) {
+    try {
+      planText = await readFile(path.join(process.cwd(), "paper", "plan.md"), "utf8");
+    } catch {
+      planText = "";
+    }
+  }
+
+  const { markdown, questions } = generateInquiryFromPlan(planText, input.lang as Lang);
+
+  const files = [
+    { path: "paper/inquiry.md", content: markdown },
+    { path: "paper/inquiry.json", content: JSON.stringify({ questions }, null, 2) }
+  ];
+
+  let saved;
+  try {
+    saved = await saveSnapshot(files, "inquiry", input.lang, input.slug, input.v);
+  } catch (e:any) {
+    return new Response(JSON.stringify({ error: "snapshot_failed", detail: e?.message || String(e) }), { status: 500 });
+  }
+
+  return new Response(
+    JSON.stringify({ text: markdown, questions, files: saved.files, covers: saved.covers }),
+    {
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+        "Access-Control-Allow-Origin": "*"
+      }
+    }
+  );
+}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -102,16 +102,24 @@ export default function Editor() {
     setBusy(true); setMsg("");
     try {
       if (!target || !lang) throw new Error("missing_target_lang");
-      const res = await fetch("/api/generate", {
+      const url = target === "inquiry" ? "/api/inquiry" : "/api/generate";
+      const payload =
+        target === "inquiry"
+          ? { lang, plan: text, slug, v }
+          : { target, lang, model, max_tokens: maxTokens, text, slug, v };
+      const res = await fetch(url, {
         method: "POST",
         headers,
-        body: JSON.stringify({ target, lang, model, max_tokens: maxTokens, text, slug, v })
+        body: JSON.stringify(payload)
       });
       const j = await res.json();
       if (!res.ok) throw new Error(j?.error || "generate_failed");
       setOut(j?.text || "");
-      setVerify(j?.checks || null);
-      setMsg(`OK • model=${j?.model_used} • in=${j?.tokens_in} • out=${j?.tokens_out} • ${j?.latency_ms}ms`);
+      if (target !== "inquiry") setVerify(j?.checks || null);
+      else setVerify(null);
+      if (target !== "inquiry")
+        setMsg(`OK • model=${j?.model_used} • in=${j?.tokens_in} • out=${j?.tokens_out} • ${j?.latency_ms}ms`);
+      else setMsg("OK");
       if (Array.isArray(j?.files)) setFiles(j.files);
       else await refreshFiles();
     } catch (e:any) {

--- a/src/lib/utils/inquiry.ts
+++ b/src/lib/utils/inquiry.ts
@@ -1,0 +1,66 @@
+import crypto from "crypto";
+
+export type Lang =
+  | "ar"
+  | "en"
+  | "tr"
+  | "fr"
+  | "es"
+  | "de"
+  | "ru"
+  | "zh-Hans"
+  | "ja"
+  | "other";
+
+export interface InquiryQuestion {
+  question: string;
+  covers: string[];
+}
+
+function sha256Hex(data: string): string {
+  return crypto.createHash("sha256").update(Buffer.from(data)).digest("hex");
+}
+
+const PROMPTS: Record<Lang, string> = {
+  ar: "يرجى توضيح",
+  en: "Please clarify",
+  tr: "Lütfen açıklayın",
+  fr: "Veuillez clarifier",
+  es: "Por favor aclare",
+  de: "Bitte erläutern",
+  ru: "Пожалуйста, уточните",
+  "zh-Hans": "请说明",
+  ja: "説明してください",
+  other: "Please clarify"
+};
+
+/**
+ * Generate an inquiry (list of questions) based on a plan in Markdown.
+ * Each question includes a `covers` field with the sha256 of the plan line it covers.
+ */
+export function generateInquiryFromPlan(planText: string, lang: Lang): {
+  markdown: string;
+  questions: InquiryQuestion[];
+} {
+  const lines = planText
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l && (/^[-*]/.test(l) || /^\d+\./.test(l)));
+
+  const prefix = PROMPTS[lang] || PROMPTS.en;
+
+  const questions: InquiryQuestion[] = lines.map((line) => {
+    const item = line.replace(/^[-*]\s*/, "").replace(/^\d+\.\s*/, "");
+    const hash = sha256Hex(item);
+    return {
+      question: `${prefix}: ${item}?`,
+      covers: [hash]
+    };
+  });
+
+  const markdown = questions
+    .map((q, i) => `${i + 1}. ${q.question}`)
+    .join("\n");
+
+  return { markdown, questions };
+}

--- a/src/lib/utils/snapshot.ts
+++ b/src/lib/utils/snapshot.ts
@@ -62,12 +62,29 @@ export async function saveSnapshot(
   }
 
   if (target === "inquiry") {
-    if (roleData["plan.md"]) covers.push(sha256Hex(roleData["plan.md"]));
-    if (roleData["judge.json"]) covers.push(sha256Hex(roleData["judge.json"]));
-    files.push({
-      path: "paper/inquiry.json",
-      content: JSON.stringify({ covers }, null, 2)
-    });
+    const coverSet = new Set<string>();
+    if (roleData["plan.md"]) coverSet.add(sha256Hex(roleData["plan.md"]));
+    if (roleData["judge.json"]) coverSet.add(sha256Hex(roleData["judge.json"]));
+
+    const inquiryFile = files.find((f) => f.path === "paper/inquiry.json");
+    if (inquiryFile) {
+      try {
+        const raw =
+          typeof inquiryFile.content === "string"
+            ? inquiryFile.content
+            : Buffer.from(inquiryFile.content).toString("utf8");
+        const j = JSON.parse(raw);
+        if (Array.isArray(j?.questions)) {
+          for (const q of j.questions) {
+            if (Array.isArray(q?.covers)) {
+              for (const c of q.covers) coverSet.add(c);
+            }
+          }
+        }
+      } catch {}
+    }
+
+    covers.push(...coverSet);
   }
 
   for (const f of files) {

--- a/test/advisor.test.ts
+++ b/test/advisor.test.ts
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { generateInquiryFromPlan } from '../src/lib/utils/inquiry';
+
+const samplePlan = `- Define scope
+- Collect data`;
+
+test('generateInquiryFromPlan creates questions with covers', () => {
+  const { markdown, questions } = generateInquiryFromPlan(samplePlan, 'en');
+  assert.strictEqual(questions.length, 2);
+  assert(markdown.includes('1.'));
+  assert(questions[0].covers[0]);
+  assert(questions[0].question.includes('Define scope'));
+});


### PR DESCRIPTION
## Summary
- add advisor utility to turn plan.md into localized questions with sha256 covers
- expose `/api/inquiry` to persist inquiry.md and inquiry.json snapshots
- update Editor to request inquiries in any supported language

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ts-node)*
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_689f4b7e5d2c83219f9143c1d3814b39