### PR TITLE
feat: support custom user criteria

### DIFF
--- a/src/lib/runJudge.ts
+++ b/src/lib/runJudge.ts
@@ -1,0 +1,59 @@
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { evaluateQN21 } from "./q21";
+import { getActiveCriteria, UserCriterion } from "./userCriteria";
+
+export interface JudgeCriterionOutput {
+  id: number;
+  name: string;
+  score: number;
+  type: "internal" | "external";
+  covered: boolean;
+}
+
+export interface JudgeReportOutput {
+  score_total: number;
+  criteria: JudgeCriterionOutput[];
+}
+
+/**
+ * Run QN-21 evaluation and any active user criteria on the supplied text.
+ * The combined report is saved to paper/judge.json and returned.
+ */
+export async function runJudge(
+  text: string,
+  userCriteria: UserCriterion[] = [],
+  outFile = path.join(process.cwd(), "paper", "judge.json")
+): Promise<JudgeReportOutput> {
+  const qn21 = evaluateQN21(text);
+  const activeUser = getActiveCriteria(userCriteria);
+
+  const qn21Mapped: JudgeCriterionOutput[] = qn21.map((c, idx) => ({
+    id: idx + 1,
+    name: c.code,
+    type: c.type,
+    score: c.score,
+    covered: c.score >= c.weight,
+  }));
+
+  const userMapped: JudgeCriterionOutput[] = activeUser.map((c, idx) => {
+    const covered = text.toLowerCase().includes(c.name.toLowerCase());
+    return {
+      id: qn21Mapped.length + idx + 1,
+      name: c.name,
+      type: c.type,
+      score: covered ? 1 : 0,
+      covered,
+    };
+  });
+
+  const criteria = [...qn21Mapped, ...userMapped];
+  const score_total = criteria.reduce((sum, c) => sum + c.score, 0);
+
+  const report: JudgeReportOutput = { score_total, criteria };
+
+  await mkdir(path.dirname(outFile), { recursive: true });
+  await writeFile(outFile, JSON.stringify(report, null, 2));
+
+  return report;
+}

--- a/src/lib/userCriteria.ts
+++ b/src/lib/userCriteria.ts
@@ -1,0 +1,37 @@
+export interface UserCriterion {
+  /** User-friendly name of the criterion */
+  name: string;
+  /** Whether the criterion is internal or external */
+  type: "internal" | "external";
+  /** Optional description clarifying the criterion */
+  description: string;
+  /** Whether the criterion should be used during evaluation */
+  isActive: boolean;
+}
+
+const STORAGE_KEY = "qaadi-user-criteria";
+
+/** Load criteria from localStorage (browser only). */
+export function loadUserCriteria(): UserCriterion[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as UserCriterion[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Persist criteria to localStorage (browser only). */
+export function saveUserCriteria(criteria: UserCriterion[]) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(criteria));
+  } catch {}
+}
+
+/** Return only the criteria that are currently active. */
+export function getActiveCriteria(list?: UserCriterion[]): UserCriterion[] {
+  const criteria = list ?? loadUserCriteria();
+  return criteria.filter((c) => c.isActive);
+}


### PR DESCRIPTION
## Summary
- add `userCriteria` helpers for storing and loading custom evaluation criteria
- extend `Editor` with UI to manage and toggle user criteria
- runJudge now appends active user criteria results to `judge.json`

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_689f4b79d9808321b3f4b614311ccb18