### PR TITLE
feat: orchestrator and worker roles pipeline

### DIFF
--- a/src/lib/utils/snapshot.ts
+++ b/src/lib/utils/snapshot.ts
@@ -52,7 +52,8 @@ export async function saveSnapshot(
     "judge.json",
     "plan.md",
     "notes.txt",
-    "comparison.md"
+    "comparison.md",
+    "summary.md"
   ];
   const roleData: Record<string, Buffer> = {};
   for (const name of roleNames) {

--- a/src/lib/workers/consultant.ts
+++ b/src/lib/workers/consultant.ts
@@ -1,0 +1,10 @@
+import { writeFile, mkdir } from "fs/promises";
+import path from "path";
+
+export async function runConsultant() {
+  const content = "Consultant notes\n";
+  const filePath = path.join(process.cwd(), "paper", "notes.txt");
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, "utf8");
+  return content;
+}

--- a/src/lib/workers/index.ts
+++ b/src/lib/workers/index.ts
@@ -1,0 +1,6 @@
+export { runSecretary } from "./secretary";
+export { runResearchSecretary } from "./researchSecretary";
+export { runJudge } from "./judge";
+export { runConsultant } from "./consultant";
+export { runLead } from "./lead";
+export { runJournalist } from "./journalist";

--- a/src/lib/workers/journalist.ts
+++ b/src/lib/workers/journalist.ts
@@ -1,0 +1,13 @@
+import { writeFile, readFile, mkdir } from "fs/promises";
+import path from "path";
+
+export async function runJournalist() {
+  const comparisonPath = path.join(process.cwd(), "paper", "comparison.md");
+  let base = "";
+  try { base = await readFile(comparisonPath, "utf8"); } catch {}
+  const content = `# Summary\n${base}`;
+  const filePath = path.join(process.cwd(), "paper", "summary.md");
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, "utf8");
+  return content;
+}

--- a/src/lib/workers/judge.ts
+++ b/src/lib/workers/judge.ts
@@ -1,0 +1,10 @@
+import { writeFile, mkdir } from "fs/promises";
+import path from "path";
+
+export async function runJudge() {
+  const result = { verdict: "approved" };
+  const filePath = path.join(process.cwd(), "paper", "judge.json");
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(result, null, 2), "utf8");
+  return result;
+}

--- a/src/lib/workers/lead.ts
+++ b/src/lib/workers/lead.ts
@@ -1,0 +1,19 @@
+import { readFile, writeFile, mkdir } from "fs/promises";
+import path from "path";
+
+export async function runLead(cards: string[]) {
+  const dir = path.join(process.cwd(), "paper");
+  let combined = "";
+  for (const name of cards) {
+    const safe = name.replace(/[^a-z0-9_-]/gi, "_");
+    try {
+      const planPath = path.join(dir, `plan-${safe}.md`);
+      const plan = await readFile(planPath, "utf8");
+      combined += `## ${safe}\n${plan}\n`;
+    } catch {}
+  }
+  const filePath = path.join(dir, "comparison.md");
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, combined, "utf8");
+  return combined;
+}

--- a/src/lib/workers/researchSecretary.ts
+++ b/src/lib/workers/researchSecretary.ts
@@ -1,0 +1,11 @@
+import { writeFile, mkdir } from "fs/promises";
+import path from "path";
+
+export async function runResearchSecretary(name: string) {
+  const safeName = name.replace(/[^a-z0-9_-]/gi, "_");
+  const content = `# Plan for ${safeName}\n`;
+  const filePath = path.join(process.cwd(), "paper", `plan-${safeName}.md`);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, "utf8");
+  return { name: safeName, content };
+}

--- a/src/lib/workers/secretary.ts
+++ b/src/lib/workers/secretary.ts
@@ -1,0 +1,10 @@
+import { writeFile, mkdir } from "fs/promises";
+import path from "path";
+
+export async function runSecretary() {
+  const content = "# Secretary\n";
+  const filePath = path.join(process.cwd(), "paper", "secretary.md");
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, "utf8");
+  return content;
+}


### PR DESCRIPTION
## Summary
- add worker modules for secretary, research secretary, judge, consultant, lead, and journalist
- orchestrate role sequence in `/api/generate` with snapshot saves
- capture new summary output in snapshots

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_689f4b7879d083218cd457651b92fce6