### PR TITLE
fix: add ESM jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};


### PR DESCRIPTION
## Summary
- add `jest.config.js` for ts-jest tests using ESM

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_689f826c3d648321a3837dcf498396e9