### PR TITLE
fix: avoid client metadata conflict in layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "./globals.css";
 import type { Metadata } from "next";
-import Script from "next/script";
 import LangDirProvider from "../components/LangDirProvider";
+import ServiceWorkerRegister from "../components/ServiceWorkerRegister";
 
 export const metadata: Metadata = {
   title: "Qaadi Live",
@@ -26,18 +26,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           sizes="32x32"
         />
         <link rel="manifest" href="/manifest.webmanifest" />
-        <Script
-          id="sw-register"
-          strategy="afterInteractive"
-          onLoad={() => {
-            if ("serviceWorker" in navigator) {
-              navigator.serviceWorker.register("/sw.js").catch(() => {});
-            }
-          }}
-        />
       </head>
       <body>
         <LangDirProvider />
+        <ServiceWorkerRegister />
         <div className="wrapper">{children}</div>
       </body>
     </html>

--- a/src/components/ServiceWorkerRegister.tsx
+++ b/src/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/sw.js").catch(() => {});
+    }
+  }, []);
+  return null;
+}


### PR DESCRIPTION
## Summary
- move service worker registration to dedicated client component
- keep root layout as server component to allow metadata export

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f826f24fc8321ac31b9ce058746fb