### PR TITLE
feat: interactive secretaries and plans

### DIFF
--- a/src/lib/workers/researchSecretary.ts
+++ b/src/lib/workers/researchSecretary.ts
@@ -1,9 +1,45 @@
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
+import { createInterface } from "readline/promises";
+import { stdin as input, stdout as output } from "node:process";
 
-export async function runResearchSecretary(name: string) {
+export interface CriterionPlan {
+  criterion: string;
+  plan: string;
+}
+
+/**
+ * Generates a development plan for the given name. Plans are grouped by
+ * criteria. When criteria are not provided, the function interactively
+ * prompts the user for them.
+ */
+export async function runResearchSecretary(
+  name: string,
+  criteria?: CriterionPlan[]
+) {
   const safeName = name.replace(/[^a-z0-9_-]/gi, "_");
-  const content = `# Plan for ${safeName}\n`;
+
+  let plans: CriterionPlan[] = criteria ?? [];
+  if (!criteria) {
+    const rl = createInterface({ input, output });
+    try {
+      const countStr = await rl.question("Number of criteria: ");
+      const count = Math.max(0, parseInt(countStr, 10) || 0);
+      for (let i = 0; i < count; i++) {
+        const criterion = await rl.question(`Criterion ${i + 1}: `);
+        const plan = await rl.question(`Plan for ${criterion}: `);
+        plans.push({ criterion, plan });
+      }
+    } finally {
+      rl.close();
+    }
+  }
+
+  const sections = plans
+    .map((p) => [`## ${p.criterion}`, p.plan])
+    .flat();
+  const content = ["# Plan for " + safeName, "", ...sections, ""].join("\n");
+
   const filePath = path.join(process.cwd(), "paper", `plan-${safeName}.md`);
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, content, "utf8");

--- a/src/lib/workers/secretary.ts
+++ b/src/lib/workers/secretary.ts
@@ -1,8 +1,55 @@
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
+import { createInterface } from "readline/promises";
+import { stdin as input, stdout as output } from "node:process";
 
-export async function runSecretary() {
-  const content = "# Secretary\n";
+export interface SecretaryData {
+  summary: string;
+  conditions: string;
+  equations: string[];
+}
+
+/**
+ * Collects high level project information and writes a markdown file
+ * describing the gathered requirements. When no data is supplied the
+ * function falls back to interactive prompts on the command line.
+ */
+export async function runSecretary(data?: SecretaryData) {
+  let summary: string;
+  let conditions: string;
+  let equations: string[];
+
+  if (!data) {
+    const rl = createInterface({ input, output });
+    try {
+      summary = await rl.question("Summary: ");
+      conditions = await rl.question("Conditions: ");
+      const eqInput = await rl.question("Equations (comma separated): ");
+      equations = eqInput
+        .split(",")
+        .map((e) => e.trim())
+        .filter(Boolean);
+    } finally {
+      rl.close();
+    }
+  } else {
+    ({ summary, conditions, equations } = data);
+  }
+
+  const content = [
+    "# Secretary",
+    "",
+    "## Summary",
+    summary,
+    "",
+    "## Conditions",
+    conditions,
+    "",
+    "## Equations",
+    ...equations.map((e) => `- ${e}`),
+    "",
+  ].join("\n");
+
   const filePath = path.join(process.cwd(), "paper", "secretary.md");
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, content, "utf8");

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { mkdtemp } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { runSecretary, runResearchSecretary } from '../src/lib/workers';
+
+const sampleSecretary = {
+  summary: 'Project overview',
+  conditions: 'All prerequisites must be met',
+  equations: ['E=mc^2', 'a^2 + b^2 = c^2']
+};
+
+const sampleCriteria = [
+  { criterion: 'performance', plan: 'Optimize algorithms' },
+  { criterion: 'usability', plan: 'Improve interface' }
+];
+
+test('runSecretary generates a complete secretary.md', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  try {
+    const content = await runSecretary(sampleSecretary);
+    const filePath = path.join(dir, 'paper', 'secretary.md');
+    const fileContent = await readFile(filePath, 'utf8');
+    assert.strictEqual(fileContent, content);
+    assert.match(fileContent, /## Summary\nProject overview/);
+    assert.match(fileContent, /## Conditions\nAll prerequisites must be met/);
+    assert.match(fileContent, /## Equations\n- E=mc\^2\n- a\^2 \+ b\^2 = c\^2/);
+  } finally {
+    process.chdir(prev);
+  }
+});
+
+test('runResearchSecretary writes plan files with criteria sections', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  try {
+    const { name, content } = await runResearchSecretary('alpha', sampleCriteria);
+    const filePath = path.join(dir, 'paper', `plan-${name}.md`);
+    const fileContent = await readFile(filePath, 'utf8');
+    assert.strictEqual(fileContent, content);
+    assert.match(fileContent, /# Plan for alpha/);
+    assert.match(fileContent, /## performance\nOptimize algorithms/);
+    assert.match(fileContent, /## usability\nImprove interface/);
+  } finally {
+    process.chdir(prev);
+  }
+});


### PR DESCRIPTION
## Summary
- expand runSecretary to collect summary, conditions, and equations and produce a full secretary.md
- generate criterion-based plan files in runResearchSecretary
- add integration tests to verify the structure of the produced files

## Testing
- `npm test` *(fails: jest: not found)*
- `npx jest --version` *(fails: 403 Forbidden - registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68a04ee360f48321ab400c552432a908