### PR TITLE
feat: enforce secretary required fields in gate

### DIFF
--- a/src/lib/workflow/gates.ts
+++ b/src/lib/workflow/gates.ts
@@ -3,25 +3,41 @@ export interface GateResult {
   missing: string[];
 }
 
+// Fields that must be present in the secretary audit
+export const SECRETARY_REQUIRED_FIELDS = ["summary", "equations", "references"] as const;
+
 // Check mandatory fields inside secretary audit
 export function runGates(data: any): GateResult {
   const audit = data?.secretary?.audit ?? data;
   const missing: string[] = [];
 
   if (!audit || typeof audit !== "object") {
-    missing.push("audit");
+    missing.push("audit object missing");
     return { ready_percent: 0, missing };
   }
 
   if (typeof audit.ready_percent !== "number") {
-    missing.push("ready_percent");
+    missing.push("ready_percent missing or invalid");
   }
   if (!Array.isArray(audit.issues)) {
-    missing.push("issues");
+    missing.push("issues missing or invalid");
+  }
+
+  for (const field of SECRETARY_REQUIRED_FIELDS) {
+    const value = (audit as any)[field];
+    const isEmpty =
+      value === undefined ||
+      value === null ||
+      (typeof value === "string" && !value.trim()) ||
+      (Array.isArray(value) && value.length === 0);
+    if (isEmpty) {
+      missing.push(`${field} missing`);
+    }
   }
 
   return {
-    ready_percent: typeof audit.ready_percent === "number" ? audit.ready_percent : 0,
+    ready_percent:
+      typeof audit.ready_percent === "number" ? audit.ready_percent : 0,
     missing
   };
 }

--- a/src/lib/workflow/index.ts
+++ b/src/lib/workflow/index.ts
@@ -1,2 +1,2 @@
-export { runGates } from "./gates";
+export { runGates, SECRETARY_REQUIRED_FIELDS } from "./gates";
 export type { GateResult } from "./gates";

--- a/templates/secretary.md
+++ b/templates/secretary.md
@@ -1,0 +1,9 @@
+# Secretary Template
+
+The secretary audit must cover the following mandatory fields:
+
+- Summary
+- Equations
+- References
+
+Provide concise notes for each section. Missing sections will block the judge stage.

--- a/test/workflow-gates.test.ts
+++ b/test/workflow-gates.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { runGates, SECRETARY_REQUIRED_FIELDS } from '../src/lib/workflow';
+
+test('reports missing secretary fields with detail', () => {
+  const audit: any = { ready_percent: 70, issues: [] };
+  const res = runGates({ secretary: { audit } });
+  const expectedMissing = SECRETARY_REQUIRED_FIELDS.map((f) => `${f} missing`);
+  assert.deepStrictEqual(res.missing, expectedMissing);
+});
+
+test('passes when all secretary fields exist', () => {
+  const audit: any = {
+    ready_percent: 90,
+    issues: [],
+    summary: 'ok',
+    equations: ['E=mc^2'],
+    references: ['ref1']
+  };
+  const res = runGates({ secretary: { audit } });
+  assert.strictEqual(res.missing.length, 0);
+  assert.strictEqual(res.ready_percent, 90);
+});


### PR DESCRIPTION
## Summary
- define mandatory secretary fields (summary, equations, references)
- enhance runGates to report missing fields in detail and export field list
- update secretary template and add unit tests for gate behavior

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a04ee6e0d8832198c0f692eb9d2042