### PR TITLE
refactor: extract prompt builder and snapshot utilities

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -3,7 +3,8 @@ import { InputSchema, OutputSchema } from "../../../lib/schema/io";
 import { runWithFallback } from "../../../lib/providers/router";
 import { freezeText, restoreText, countEquations, FrozenText } from "../../../lib/utils/freeze";
 import { checkIdempotency } from "../../../lib/utils/idempotency";
-import { saveSnapshot } from "../../../lib/utils/snapshot";
+import { saveSnapshot } from "../../../lib/saveSnapshot";
+import { buildPrompt } from "../../../lib/buildPrompt";
 import fs from "fs/promises";
 import path from "path";
 import {
@@ -205,121 +206,8 @@ export async function POST(req: NextRequest) {
   } catch (e:any) {
     return new Response(JSON.stringify({ error: "provider_error", detail: e?.message || String(e) }), { status: 502 });
   }
-}
-
-export { saveSnapshot };
-
-export function buildPrompt(
-  target:
-    | "wide"
-    | "revtex"
-    | "inquiry"
-    | "iop"
-    | "sn-jnl"
-    | "elsevier"
-    | "ieee"
-    | "arxiv",
-  lang:
-    | "ar"
-    | "en"
-    | "tr"
-    | "fr"
-    | "es"
-    | "de"
-    | "ru"
-    | "zh-Hans"
-    | "ja"
-    | "other",
-  userText: string,
-  glossary: Record<string, string> | null
-): { prompt: string; frozen: FrozenText } {
-  const frozen = freezeText(userText);
-  const gloss =
-    glossary && Object.keys(glossary).length
-      ? "\nGlossary:\n" +
-        Object.entries(glossary)
-          .map(([k, v]) => `${k} = ${v}`)
-          .join("\n")
-      : "";
-
-  if (target === "wide") {
-    if (lang === "ar")
-      return { prompt: `WIDE/AR: أنت محرّك Qaadi. حرّر نصًا عربيًا واسعًا موجّهًا للورقة (bundle.md). المدخل:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "en")
-      return { prompt: `WIDE/EN: You are the Qaadi engine. Edit a wide English text intended for the paper (bundle.md). Input:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "tr")
-      return { prompt: `WIDE/TR: Qaadi motorusun. Makale için geniş Türkçe metni düzenle (bundle.md). Girdi:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "fr")
-      return { prompt: `WIDE/FR: Tu es le moteur Qaadi. Édite un texte français étendu destiné au papier (bundle.md). Entrée :\n${frozen.text}${gloss}`, frozen };
-    if (lang === "de")
-      return { prompt: `WIDE/DE: Du bist der Qaadi-Motor. Bearbeite einen ausführlichen deutschen Text für das Papier (bundle.md). Eingabe:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "es")
-      return { prompt: `WIDE/ES: Eres el motor Qaadi. Edita texto español amplio dirigido al artículo (bundle.md). Entrada:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "ru")
-      return { prompt: `WIDE/RU: Ты движок Qaadi. Редактируй широкий русский текст для статьи (bundle.md). Ввод:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "zh-Hans")
-      return { prompt: `WIDE/ZH-HANS: 你是 Qaadi 引擎。编辑面向论文的中文长文 (bundle.md)。输入:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "ja")
-      return { prompt: `WIDE/JA: あなたは Qaadi エンジンです。論文用の日本語の長文を編集してください (bundle.md)。入力:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "other")
-      return { prompt: `WIDE/OTHER: You are the Qaadi engine. Edit a long text in its original language intended for the paper (bundle.md). Input:\n${frozen.text}${gloss}`, frozen };
   }
-  if (target === "inquiry") {
-    if (lang === "ar")
-      return { prompt: `INQUIRY/AR: أنت محرّك Qaadi. أجب على استفسار عربي موجه للورقة (inquiry.md). المدخل:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "en")
-      return { prompt: `INQUIRY/EN: You are the Qaadi engine. Answer an English inquiry intended for the paper (inquiry.md). Input:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "tr")
-      return { prompt: `INQUIRY/TR: Qaadi motorusun. Makale için Türkçe bir soruyu yanıtla (inquiry.md). Girdi:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "fr")
-      return { prompt: `INQUIRY/FR: Tu es le moteur Qaadi. Réponds à une requête française destinée à l'article (inquiry.md). Entrée :\n${frozen.text}${gloss}`, frozen };
-    if (lang === "de")
-      return { prompt: `INQUIRY/DE: Du bist der Qaadi-Motor. Beantworte eine deutsche Anfrage für den Artikel (inquiry.md). Eingabe:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "es")
-      return { prompt: `INQUIRY/ES: Eres el motor Qaadi. Responde una consulta en español destinada al artículo (inquiry.md). Entrada:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "ru")
-      return { prompt: `INQUIRY/RU: Ты движок Qaadi. Ответь на русский запрос для статьи (inquiry.md). Ввод:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "zh-Hans")
-      return { prompt: `INQUIRY/ZH-HANS: 你是 Qaadi 引擎。用中文回答一个面向论文的询问 (inquiry.md)。输入:\n${frozen.text}${gloss}`, frozen };
-    if (lang === "ja")
-      return { prompt: `INQUIRY/JA: あなたは Qaadi エンジンです。論文用の日本語の問いに答えてください (inquiry.md)。入力:\n${frozen.text}${gloss}`, frozen };
-    throw new Error("unsupported_inquiry_lang");
-  }
-  const templateTargets = new Set(["revtex", "iop", "sn-jnl", "elsevier", "ieee", "arxiv"]);
-  if (templateTargets.has(target)) {
-    if (lang === "other") throw new Error(`unsupported_template_lang:${target}:${lang}`);
-    const langNames: Record<string, string> = {
-      ar: "Arabic",
-      en: "English",
-      tr: "Turkish",
-      fr: "French",
-      es: "Spanish",
-      de: "German",
-      ru: "Russian",
-      "zh-Hans": "Chinese (Simplified)",
-      ja: "Japanese"
-    };
-    const targetNames: Record<string, string> = {
-      revtex: "ReVTeX",
-      iop: "IOP",
-      "sn-jnl": "Springer Nature Journal",
-      elsevier: "Elsevier",
-      ieee: "IEEE",
-      arxiv: "arXiv"
-    };
-    const langName = langNames[lang];
-    const tName = targetNames[target];
-    if (!langName || !tName)
-      throw new Error(`unsupported_target_lang:${target}:${lang}`);
-    return {
-      prompt: `${target.toUpperCase()}/${lang.toUpperCase()}: Produce LaTeX draft body (no \\documentclass) for ${tName} style in ${langName}. Input:\n${frozen.text}${gloss}`,
-      frozen
-    };
-  }
-  throw new Error(`unsupported_target_lang:${target}:${lang}`);
-}
-
-async function loadGlossary(req: NextRequest): Promise<Record<string, string> | null> {
+  async function loadGlossary(req: NextRequest): Promise<Record<string, string> | null> {
   const combined: Record<string, string> = {};
   try {
     const defsPath = path.join(process.cwd(), "docs", "definitions.json");

--- a/src/lib/buildPrompt.ts
+++ b/src/lib/buildPrompt.ts
@@ -1,0 +1,111 @@
+import { freezeText, FrozenText } from "./utils/freeze";
+
+export function buildPrompt(
+  target:
+    | "wide"
+    | "revtex"
+    | "inquiry"
+    | "iop"
+    | "sn-jnl"
+    | "elsevier"
+    | "ieee"
+    | "arxiv",
+  lang:
+    | "ar"
+    | "en"
+    | "tr"
+    | "fr"
+    | "es"
+    | "de"
+    | "ru"
+    | "zh-Hans"
+    | "ja"
+    | "other",
+  userText: string,
+  glossary: Record<string, string> | null
+): { prompt: string; frozen: FrozenText } {
+  const frozen = freezeText(userText);
+  const gloss =
+    glossary && Object.keys(glossary).length
+      ? "\nGlossary:\n" +
+        Object.entries(glossary)
+          .map(([k, v]) => `${k} = ${v}`)
+          .join("\n")
+      : "";
+
+  if (target === "wide") {
+    if (lang === "ar")
+      return { prompt: `WIDE/AR: أنت محرّك Qaadi. حرّر نصًا عربيًا واسعًا موجّهًا للورقة (bundle.md). المدخل:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "en")
+      return { prompt: `WIDE/EN: You are the Qaadi engine. Edit a wide English text intended for the paper (bundle.md). Input:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "tr")
+      return { prompt: `WIDE/TR: Qaadi motorusun. Makale için geniş Türkçe metni düzenle (bundle.md). Girdi:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "fr")
+      return { prompt: `WIDE/FR: Tu es le moteur Qaadi. Édite un texte français étendu destiné au papier (bundle.md). Entrée :\n${frozen.text}${gloss}`, frozen };
+    if (lang === "de")
+      return { prompt: `WIDE/DE: Du bist der Qaadi-Motor. Bearbeite einen ausführlichen deutschen Text für das Papier (bundle.md). Eingabe:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "es")
+      return { prompt: `WIDE/ES: Eres el motor Qaadi. Edita texto español amplio dirigido al artículo (bundle.md). Entrada:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "ru")
+      return { prompt: `WIDE/RU: Ты движок Qaadi. Редактируй широкий русский текст для статьи (bundle.md). Ввод:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "zh-Hans")
+      return { prompt: `WIDE/ZH-HANS: 你是 Qaadi 引擎。编辑面向论文的中文长文 (bundle.md)。输入:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "ja")
+      return { prompt: `WIDE/JA: あなたは Qaadi エンジンです。論文用の日本語の長文を編集してください (bundle.md)。入力:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "other")
+      return { prompt: `WIDE/OTHER: You are the Qaadi engine. Edit a long text in its original language intended for the paper (bundle.md). Input:\n${frozen.text}${gloss}`, frozen };
+  }
+  if (target === "inquiry") {
+    if (lang === "ar")
+      return { prompt: `INQUIRY/AR: أنت محرّك Qaadi. أجب على استفسار عربي موجه للورقة (inquiry.md). المدخل:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "en")
+      return { prompt: `INQUIRY/EN: You are the Qaadi engine. Answer an English inquiry intended for the paper (inquiry.md). Input:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "tr")
+      return { prompt: `INQUIRY/TR: Qaadi motorusun. Makale için Türkçe bir soruyu yanıtla (inquiry.md). Girdi:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "fr")
+      return { prompt: `INQUIRY/FR: Tu es le moteur Qaadi. Réponds à une requête française destinée à l'article (inquiry.md). Entrée :\n${frozen.text}${gloss}`, frozen };
+    if (lang === "de")
+      return { prompt: `INQUIRY/DE: Du bist der Qaadi-Motor. Beantworte eine deutsche Anfrage für den Artikel (inquiry.md). Eingabe:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "es")
+      return { prompt: `INQUIRY/ES: Eres el motor Qaadi. Responde una consulta en español destinada al artículo (inquiry.md). Entrada:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "ru")
+      return { prompt: `INQUIRY/RU: Ты движок Qaadi. Ответь на русский запрос для статьи (inquiry.md). Ввод:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "zh-Hans")
+      return { prompt: `INQUIRY/ZH-HANS: 你是 Qaadi 引擎。用中文回答一个面向论文的询问 (inquiry.md)。输入:\n${frozen.text}${gloss}`, frozen };
+    if (lang === "ja")
+      return { prompt: `INQUIRY/JA: あなたは Qaadi エンジンです。論文用の日本語の問いに答えてください (inquiry.md)。入力:\n${frozen.text}${gloss}`, frozen };
+    throw new Error("unsupported_inquiry_lang");
+  }
+  const templateTargets = new Set(["revtex", "iop", "sn-jnl", "elsevier", "ieee", "arxiv"]);
+  if (templateTargets.has(target)) {
+    if (lang === "other") throw new Error(`unsupported_template_lang:${target}:${lang}`);
+    const langNames: Record<string, string> = {
+      ar: "Arabic",
+      en: "English",
+      tr: "Turkish",
+      fr: "French",
+      es: "Spanish",
+      de: "German",
+      ru: "Russian",
+      "zh-Hans": "Chinese (Simplified)",
+      ja: "Japanese"
+    };
+    const targetNames: Record<string, string> = {
+      revtex: "ReVTeX",
+      iop: "IOP",
+      "sn-jnl": "Springer Nature Journal",
+      elsevier: "Elsevier",
+      ieee: "IEEE",
+      arxiv: "arXiv"
+    };
+    const langName = langNames[lang];
+    const tName = targetNames[target];
+    if (!langName || !tName)
+      throw new Error(`unsupported_target_lang:${target}:${lang}`);
+    return {
+      prompt: `${target.toUpperCase()}/${lang.toUpperCase()}: Produce LaTeX draft body (no \\documentclass) for ${tName} style in ${langName}. Input:\n${frozen.text}${gloss}`,
+      frozen
+    };
+  }
+  throw new Error(`unsupported_target_lang:${target}:${lang}`);
+}

--- a/src/lib/saveSnapshot.ts
+++ b/src/lib/saveSnapshot.ts
@@ -1,0 +1,1 @@
+export { saveSnapshot } from "./utils/snapshot";

--- a/test/inquiry.test.ts
+++ b/test/inquiry.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { buildPrompt } from '../src/app/api/generate/route';
+import { buildPrompt } from '../src/lib/buildPrompt';
 
 test('buildPrompt handles inquiry in English', () => {
   const { prompt } = buildPrompt('inquiry', 'en', 'What is the role of Qaadi?', null);

--- a/test/snapshot-placeholder.test.ts
+++ b/test/snapshot-placeholder.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { readFile } from 'node:fs/promises';
-import { saveSnapshot } from '../src/app/api/generate/route';
+import { saveSnapshot } from '../src/lib/saveSnapshot';
 
 function fakeDates() {
   const realDate = Date;


### PR DESCRIPTION
## Summary
- factor out `buildPrompt` into `src/lib/buildPrompt.ts`
- expose `saveSnapshot` via shared util `src/lib/saveSnapshot.ts`
- route handler now imports shared utilities and exports only runtime and handlers

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a05f92ef088321b51cbd109f6c0fc4