### PR TITLE
docs: specify mandatory fields in secretary template

### DIFF
--- a/templates/secretary.md
+++ b/templates/secretary.md
@@ -1,3 +1,5 @@
+<!-- mandatory fields: ready_percent, issues[].type, issues[].note -->
+
 # ملخص
 يلخص هذا المستند الإطار النظري المقترح، ويعرض الأهداف والفرضيات الرئيسة للدراسة.
 


### PR DESCRIPTION
## Summary
- document required secretary audit fields at the top of the template

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a05f9150988321a7970cb34e034faf