### PR TITLE
refactor: migrate tests to Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,10 @@
 export default {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
 };

--- a/test/advisor.test.ts
+++ b/test/advisor.test.ts
@@ -1,14 +1,15 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { describe, it, expect } from '@jest/globals';
 import { generateInquiryFromPlan } from '../src/lib/utils/inquiry';
 
 const samplePlan = `- Define scope
 - Collect data`;
 
-test('generateInquiryFromPlan creates questions with covers', () => {
-  const { markdown, questions } = generateInquiryFromPlan(samplePlan, 'en');
-  assert.strictEqual(questions.length, 2);
-  assert(markdown.includes('1.'));
-  assert(questions[0].covers[0]);
-  assert(questions[0].question.includes('Define scope'));
+describe('generateInquiryFromPlan', () => {
+  it('creates questions with covers', () => {
+    const { markdown, questions } = generateInquiryFromPlan(samplePlan, 'en');
+    expect(questions).toHaveLength(2);
+    expect(markdown).toContain('1.');
+    expect(questions[0].covers[0]).toBeTruthy();
+    expect(questions[0].question).toContain('Define scope');
+  });
 });

--- a/test/editor-disabled.test.ts
+++ b/test/editor-disabled.test.ts
@@ -1,29 +1,30 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { describe, it, expect } from '@jest/globals';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import Editor from '../src/components/Editor';
 
-test('export and generate buttons require target and lang', () => {
-  // initial render without target/lang -> buttons disabled
-  const initial = renderToStaticMarkup(React.createElement(Editor));
-  assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
-  assert.match(initial, /<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
-  assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
+describe('Editor', () => {
+  it('export and generate buttons require target and lang', () => {
+    // initial render without target/lang -> buttons disabled
+    const initial = renderToStaticMarkup(React.createElement(Editor));
+    expect(initial).toMatch(/<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
+    expect(initial).toMatch(/<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
+    expect(initial).toMatch(/<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
 
-  // render with target and lang preset -> buttons enabled
-  const origUseState = React.useState;
-  let calls = 0;
-  (React as any).useState = (init: any) => {
-    calls++;
-    if (calls === 3) return ['revtex', () => {}]; // target
-    if (calls === 4) return ['en', () => {}]; // lang
-    return origUseState(init);
-  };
-  const withValues = renderToStaticMarkup(React.createElement(Editor));
-  (React as any).useState = origUseState;
+    // render with target and lang preset -> buttons enabled
+    const origUseState = React.useState;
+    let calls = 0;
+    (React as any).useState = (init: any) => {
+      calls++;
+      if (calls === 3) return ['revtex', () => {}]; // target
+      if (calls === 4) return ['en', () => {}]; // lang
+      return origUseState(init);
+    };
+    const withValues = renderToStaticMarkup(React.createElement(Editor));
+    (React as any).useState = origUseState;
 
-  assert.doesNotMatch(withValues, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
-  assert.doesNotMatch(withValues, /<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
-  assert.doesNotMatch(withValues, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
+    expect(withValues).not.toMatch(/<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
+    expect(withValues).not.toMatch(/<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
+    expect(withValues).not.toMatch(/<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
+  });
 });

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,25 +1,26 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { describe, it, expect } from '@jest/globals';
 import { GET } from '../src/app/api/health/route';
 
 // Ensure the health endpoint exposes the complete diagnostic schema.
-test('health endpoint exposes policies, storage, kv, and capsule fields', async () => {
-  const res = await GET();
-  assert.strictEqual(res.status, 200);
-  const body = await res.json();
+describe('health endpoint', () => {
+  it('exposes policies, storage, kv, and capsule fields', async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
 
-  assert.deepStrictEqual(body.policies, {
-    byok: true,
-    storage_public_read_capsules: true,
-    storage_public_read_theory_zips: true
+    expect(body.policies).toEqual({
+      byok: true,
+      storage_public_read_capsules: true,
+      storage_public_read_theory_zips: true,
+    });
+
+    expect(body).toHaveProperty('storage');
+    expect(body).toHaveProperty('kv');
+    expect(
+      body.capsule &&
+        'name' in body.capsule &&
+        'sha256' in body.capsule &&
+        'ts' in body.capsule
+    ).toBeTruthy();
   });
-
-  assert.ok('storage' in body);
-  assert.ok('kv' in body);
-  assert.ok(
-    body.capsule &&
-      'name' in body.capsule &&
-      'sha256' in body.capsule &&
-      'ts' in body.capsule
-  );
 });

--- a/test/inquiry.test.ts
+++ b/test/inquiry.test.ts
@@ -1,18 +1,15 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { describe, it, expect } from '@jest/globals';
 import { buildPrompt } from '../src/app/api/generate/route';
 
-test('buildPrompt handles inquiry in English', () => {
-  const { prompt } = buildPrompt('inquiry', 'en', 'What is the role of Qaadi?', null);
-  assert.strictEqual(
-    prompt,
-    'INQUIRY/EN: You are the Qaadi engine. Answer an English inquiry intended for the paper (inquiry.md). Input:\nWhat is the role of Qaadi?'
-  );
-});
+describe('buildPrompt', () => {
+  it('handles inquiry in English', () => {
+    const { prompt } = buildPrompt('inquiry', 'en', 'What is the role of Qaadi?', null);
+    expect(prompt).toBe(
+      'INQUIRY/EN: You are the Qaadi engine. Answer an English inquiry intended for the paper (inquiry.md). Input:\nWhat is the role of Qaadi?'
+    );
+  });
 
-test('buildPrompt rejects unsupported inquiry language', () => {
-  assert.throws(
-    () => buildPrompt('inquiry', 'other', 'Hello', null),
-    /unsupported_inquiry_lang/
-  );
+  it('rejects unsupported inquiry language', () => {
+    expect(() => buildPrompt('inquiry', 'other', 'Hello', null)).toThrow(/unsupported_inquiry_lang/);
+  });
 });

--- a/test/manifest-filter.test.ts
+++ b/test/manifest-filter.test.ts
@@ -1,14 +1,15 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { describe, it, expect } from '@jest/globals';
 import { latestFilesFor, ManifestEntry } from '../src/lib/utils/manifest';
 
-test('returns only files from requested version', () => {
-  const manifest: ManifestEntry[] = [
-    { slug: 'demo', v: 'v1', timestamp: '20240101T000000', path: 'v1/old.md' },
-    { slug: 'demo', v: 'v1', timestamp: '20240102T000000', path: 'v1/newer.md' },
-    { slug: 'demo', v: 'v2', timestamp: '20240103T000000', path: 'v2/only.md' },
-    { slug: 'demo', v: 'v2', timestamp: '20240104T000000', path: 'v2/latest.md' },
-  ];
-  const files = latestFilesFor(manifest, 'demo', 'v2');
-  assert.deepStrictEqual(files, ['v2/latest.md']);
+describe('latestFilesFor', () => {
+  it('returns only files from requested version', () => {
+    const manifest: ManifestEntry[] = [
+      { slug: 'demo', v: 'v1', timestamp: '20240101T000000', path: 'v1/old.md' },
+      { slug: 'demo', v: 'v1', timestamp: '20240102T000000', path: 'v1/newer.md' },
+      { slug: 'demo', v: 'v2', timestamp: '20240103T000000', path: 'v2/only.md' },
+      { slug: 'demo', v: 'v2', timestamp: '20240104T000000', path: 'v2/latest.md' },
+    ];
+    const files = latestFilesFor(manifest, 'demo', 'v2');
+    expect(files).toEqual(['v2/latest.md']);
+  });
 });

--- a/test/no-export-get-link.test.ts
+++ b/test/no-export-get-link.test.ts
@@ -1,10 +1,11 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { describe, it, expect } from '@jest/globals';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import Editor from '../src/components/Editor';
 
-test('editor has no direct GET export link', () => {
-  const markup = renderToStaticMarkup(React.createElement(Editor));
-  assert.doesNotMatch(markup, /<a[^>]+href="\/api\/export"/);
+describe('Editor', () => {
+  it('has no direct GET export link', () => {
+    const markup = renderToStaticMarkup(React.createElement(Editor));
+    expect(markup).not.toMatch(/<a[^>]+href="\/api\/export"/);
+  });
 });

--- a/test/q21.test.ts
+++ b/test/q21.test.ts
@@ -1,62 +1,61 @@
-import assert from 'node:assert';
-
+import { describe, it, expect } from '@jest/globals';
 import { evaluateQN21, QN21_CRITERIA, summarizeQN21 } from '../src/lib/q21';
 
-test('evaluateQN21 returns scores and gaps based on keywords', () => {
-  const text =
-    'The equation F = ma was derived with rigorous analysis and ethical oversight.';
-  const result = evaluateQN21(text);
+describe('QN21 utilities', () => {
+  it('evaluateQN21 returns scores and gaps based on keywords', () => {
+    const text = 'The equation F = ma was derived with rigorous analysis and ethical oversight.';
+    const result = evaluateQN21(text);
 
-  assert.strictEqual(result.length, QN21_CRITERIA.length);
+    expect(result.length).toBe(QN21_CRITERIA.length);
 
-  const sigma = result.find((r) => r.code === 'Σ');
-  assert.ok(sigma);
-  assert.strictEqual(sigma?.score, 8);
-  assert.strictEqual(sigma?.gap, 0);
+    const sigma = result.find((r) => r.code === 'Σ');
+    expect(sigma).toBeTruthy();
+    expect(sigma?.score).toBe(8);
+    expect(sigma?.gap).toBe(0);
 
-  const delta = result.find((r) => r.code === 'Δ');
-  assert.ok(delta);
-  assert.strictEqual(delta?.score, 6);
-  assert.strictEqual(delta?.gap, 0);
+    const delta = result.find((r) => r.code === 'Δ');
+    expect(delta).toBeTruthy();
+    expect(delta?.score).toBe(6);
+    expect(delta?.gap).toBe(0);
 
-  const theta = result.find((r) => r.code === 'Θ');
-  assert.ok(theta);
-  assert.strictEqual(theta?.score, 8);
-  assert.strictEqual(theta?.gap, 0);
+    const theta = result.find((r) => r.code === 'Θ');
+    expect(theta).toBeTruthy();
+    expect(theta?.score).toBe(8);
+    expect(theta?.gap).toBe(0);
 
-  const phi = result.find((r) => r.code === 'Φ');
-  assert.ok(phi);
-  assert.strictEqual(phi?.score, 0);
-  assert.strictEqual(phi?.gap, 5);
+    const phi = result.find((r) => r.code === 'Φ');
+    expect(phi).toBeTruthy();
+    expect(phi?.score).toBe(0);
+    expect(phi?.gap).toBe(5);
+  });
+
+  it('evaluateQN21 handles partial criteria in text', () => {
+    const text =
+      'Calibration ensures precision, but reproducibility was not discussed. Community engagement was strong.';
+    const result = evaluateQN21(text);
+
+    const kappa = result.find((r) => r.code === 'Κ');
+    expect(kappa).toBeTruthy();
+    expect(kappa?.score).toBe(3);
+
+    const rho = result.find((r) => r.code === 'Ρ');
+    expect(rho).toBeTruthy();
+    expect(rho?.score).toBe(0);
+
+    const beta = result.find((r) => r.code === 'Β');
+    expect(beta).toBeTruthy();
+    expect(beta?.score).toBe(5);
+  });
+
+  it('summarizeQN21 computes percentage and classification', () => {
+    const text = QN21_CRITERIA.slice(0, 17)
+      .map((c) => c.keywords[0])
+      .join(' ');
+    const result = evaluateQN21(text);
+    const summary = summarizeQN21(result);
+    expect(summary.total).toBe(17);
+    expect(summary.max).toBe(QN21_CRITERIA.length);
+    expect(summary.percentage).toBeGreaterThan(80);
+    expect(summary.classification).toBe('accepted');
+  });
 });
-
-test('evaluateQN21 handles partial criteria in text', () => {
-  const text =
-    'Calibration ensures precision, but reproducibility was not discussed. Community engagement was strong.';
-  const result = evaluateQN21(text);
-
-  const kappa = result.find((r) => r.code === 'Κ');
-  assert.ok(kappa);
-  assert.strictEqual(kappa?.score, 3);
-
-  const rho = result.find((r) => r.code === 'Ρ');
-  assert.ok(rho);
-  assert.strictEqual(rho?.score, 0);
-
-  const beta = result.find((r) => r.code === 'Β');
-  assert.ok(beta);
-  assert.strictEqual(beta?.score, 5);
-});
-
-test('summarizeQN21 computes percentage and classification', () => {
-  const text = QN21_CRITERIA.slice(0, 17)
-    .map((c) => c.keywords[0])
-    .join(' ');
-  const result = evaluateQN21(text);
-  const summary = summarizeQN21(result);
-  assert.strictEqual(summary.total, 17);
-  assert.strictEqual(summary.max, QN21_CRITERIA.length);
-  assert.ok(summary.percentage > 80);
-  assert.strictEqual(summary.classification, 'accepted');
-});
-

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -1,7 +1,5 @@
-import test from 'node:test';
-import assert from 'node:assert';
-import { mkdtemp } from 'node:fs/promises';
-import { readFile } from 'node:fs/promises';
+import { describe, it, expect } from '@jest/globals';
+import { mkdtemp, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { runSecretary, runResearchSecretary } from '../src/lib/workers';
@@ -17,36 +15,38 @@ const sampleCriteria = [
   { criterion: 'usability', plan: 'Improve interface' }
 ];
 
-test('runSecretary generates a complete secretary.md', async () => {
-  const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
-  const prev = process.cwd();
-  process.chdir(dir);
-  try {
-    const content = await runSecretary(sampleSecretary);
-    const filePath = path.join(dir, 'paper', 'secretary.md');
-    const fileContent = await readFile(filePath, 'utf8');
-    assert.strictEqual(fileContent, content);
-    assert.match(fileContent, /## Summary\nProject overview/);
-    assert.match(fileContent, /## Conditions\nAll prerequisites must be met/);
-    assert.match(fileContent, /## Equations\n- E=mc\^2\n- a\^2 \+ b\^2 = c\^2/);
-  } finally {
-    process.chdir(prev);
-  }
-});
+describe('secretary workflow', () => {
+  it('runSecretary generates a complete secretary.md', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
+    const prev = process.cwd();
+    process.chdir(dir);
+    try {
+      const content = await runSecretary(sampleSecretary);
+      const filePath = path.join(dir, 'paper', 'secretary.md');
+      const fileContent = await readFile(filePath, 'utf8');
+      expect(fileContent).toBe(content);
+      expect(fileContent).toMatch(/## Summary\nProject overview/);
+      expect(fileContent).toMatch(/## Conditions\nAll prerequisites must be met/);
+      expect(fileContent).toMatch(/## Equations\n- E=mc\^2\n- a\^2 \+ b\^2 = c\^2/);
+    } finally {
+      process.chdir(prev);
+    }
+  });
 
-test('runResearchSecretary writes plan files with criteria sections', async () => {
-  const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
-  const prev = process.cwd();
-  process.chdir(dir);
-  try {
-    const { name, content } = await runResearchSecretary('alpha', sampleCriteria);
-    const filePath = path.join(dir, 'paper', `plan-${name}.md`);
-    const fileContent = await readFile(filePath, 'utf8');
-    assert.strictEqual(fileContent, content);
-    assert.match(fileContent, /# Plan for alpha/);
-    assert.match(fileContent, /## performance\nOptimize algorithms/);
-    assert.match(fileContent, /## usability\nImprove interface/);
-  } finally {
-    process.chdir(prev);
-  }
+  it('runResearchSecretary writes plan files with criteria sections', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
+    const prev = process.cwd();
+    process.chdir(dir);
+    try {
+      const { name, content } = await runResearchSecretary('alpha', sampleCriteria);
+      const filePath = path.join(dir, 'paper', `plan-${name}.md`);
+      const fileContent = await readFile(filePath, 'utf8');
+      expect(fileContent).toBe(content);
+      expect(fileContent).toMatch(/# Plan for alpha/);
+      expect(fileContent).toMatch(/## performance\nOptimize algorithms/);
+      expect(fileContent).toMatch(/## usability\nImprove interface/);
+    } finally {
+      process.chdir(prev);
+    }
+  });
 });

--- a/test/snapshot-placeholder.test.ts
+++ b/test/snapshot-placeholder.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { describe, it, expect } from '@jest/globals';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -21,41 +20,43 @@ function fakeDates() {
   return () => { (global as any).Date = realDate; };
 }
 
-test('placeholder files have stable fingerprints on regeneration', async () => {
-  const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
-  const prev = process.cwd();
-  process.chdir(dir);
-  const restore = fakeDates();
-  try {
-    await saveSnapshot([{ path: 'paper/draft.tex', content: 'a' }], 'revtex', 'en', 'demo', 'v1');
-    await saveSnapshot([{ path: 'paper/draft.tex', content: 'b' }], 'revtex', 'en', 'demo', 'v1');
-  } finally {
-    restore();
-    process.chdir(prev);
-  }
-  const manifestPath = path.join(dir, 'public', 'snapshots', 'manifest.json');
-  const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
-  const biblio = manifest.filter((e: any) => e.path.endsWith('biblio.bib') && e.slug === 'demo' && e.v === 'v1');
-  const figs = manifest.filter((e: any) => e.path.endsWith('figs/') && e.slug === 'demo' && e.v === 'v1');
-  assert.strictEqual(biblio.length, 2);
-  assert.strictEqual(figs.length, 2);
-  assert.strictEqual(new Set(biblio.map((e: any) => e.sha256)).size, 1);
-  assert.strictEqual(new Set(figs.map((e: any) => e.sha256)).size, 1);
-});
+describe('snapshot placeholders', () => {
+  it('placeholder files have stable fingerprints on regeneration', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
+    const prev = process.cwd();
+    process.chdir(dir);
+    const restore = fakeDates();
+    try {
+      await saveSnapshot([{ path: 'paper/draft.tex', content: 'a' }], 'revtex', 'en', 'demo', 'v1');
+      await saveSnapshot([{ path: 'paper/draft.tex', content: 'b' }], 'revtex', 'en', 'demo', 'v1');
+    } finally {
+      restore();
+      process.chdir(prev);
+    }
+    const manifestPath = path.join(dir, 'public', 'snapshots', 'manifest.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+    const biblio = manifest.filter((e: any) => e.path.endsWith('biblio.bib') && e.slug === 'demo' && e.v === 'v1');
+    const figs = manifest.filter((e: any) => e.path.endsWith('figs/') && e.slug === 'demo' && e.v === 'v1');
+    expect(biblio.length).toBe(2);
+    expect(figs.length).toBe(2);
+    expect(new Set(biblio.map((e: any) => e.sha256)).size).toBe(1);
+    expect(new Set(figs.map((e: any) => e.sha256)).size).toBe(1);
+  });
 
-test('saves role files with type role', async () => {
-  const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
-  const prev = process.cwd();
-  process.chdir(dir);
-  await mkdir('paper', { recursive: true });
-  await writeFile('paper/secretary.md', 'sec');
-  try {
-    await saveSnapshot([{ path: 'paper/draft.tex', content: 'x' }], 'revtex', 'en', 'demo', 'v1');
-  } finally {
-    process.chdir(prev);
-  }
-  const manifestPath = path.join(dir, 'public', 'snapshots', 'manifest.json');
-  const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
-  const role = manifest.find((e: any) => e.path.endsWith('secretary.md'));
-  assert.ok(role && role.type === 'role');
+  it('saves role files with type role', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
+    const prev = process.cwd();
+    process.chdir(dir);
+    await mkdir('paper', { recursive: true });
+    await writeFile('paper/secretary.md', 'sec');
+    try {
+      await saveSnapshot([{ path: 'paper/draft.tex', content: 'x' }], 'revtex', 'en', 'demo', 'v1');
+    } finally {
+      process.chdir(prev);
+    }
+    const manifestPath = path.join(dir, 'public', 'snapshots', 'manifest.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+    const role = manifest.find((e: any) => e.path.endsWith('secretary.md'));
+    expect(role && role.type === 'role').toBeTruthy();
+  });
 });

--- a/test/templates-endpoint.test.ts
+++ b/test/templates-endpoint.test.ts
@@ -1,25 +1,25 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { describe, it, expect } from '@jest/globals';
 import { NextRequest } from 'next/server';
 import { GET } from '../src/app/api/templates/route';
 
 const base = 'http://localhost/api/templates';
-
 const files = ['secretary.md', 'judge.json', 'plan.md', 'comparison.md'];
 
-for (const name of files) {
-  test(`serves ${name} with no-store header`, async () => {
-    const req = new NextRequest(`${base}?name=${encodeURIComponent(name)}`);
-    const res = await GET(req);
-    assert.strictEqual(res.status, 200);
-    assert.strictEqual(res.headers.get('Cache-Control'), 'no-store');
-    const body = await res.text();
-    assert.strictEqual(body, '');
-  });
-}
+describe('templates endpoint', () => {
+  for (const name of files) {
+    it(`serves ${name} with no-store header`, async () => {
+      const req = new NextRequest(`${base}?name=${encodeURIComponent(name)}`);
+      const res = await GET(req);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Cache-Control')).toBe('no-store');
+      const body = await res.text();
+      expect(body).toBe('');
+    });
+  }
 
-test('missing template returns 404', async () => {
-  const req = new NextRequest(`${base}?name=missing.md`);
-  const res = await GET(req);
-  assert.strictEqual(res.status, 404);
+  it('missing template returns 404', async () => {
+    const req = new NextRequest(`${base}?name=missing.md`);
+    const res = await GET(req);
+    expect(res.status).toBe(404);
+  });
 });


### PR DESCRIPTION
## Summary
- rewrite all test suites using Jest's describe/it/expect APIs
- configure Jest for ESM TypeScript

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a05f8f75508321933d9150041715ff