### PR TITLE
feat: validate secretary report fields

### DIFF
--- a/src/lib/workflow/gates.ts
+++ b/src/lib/workflow/gates.ts
@@ -3,25 +3,31 @@ export interface GateResult {
   missing: string[];
 }
 
-// Check mandatory fields inside secretary audit
+// Required fields for a complete secretary report
+const REQUIRED_FIELDS = ["summary", "equations", "references"];
+
+// Check mandatory fields inside secretary report and return missing ones
 export function runGates(data: any): GateResult {
-  const audit = data?.secretary?.audit ?? data;
+  const report = data?.secretary?.audit ?? data;
   const missing: string[] = [];
 
-  if (!audit || typeof audit !== "object") {
-    missing.push("audit");
-    return { ready_percent: 0, missing };
+  if (!report || typeof report !== "object") {
+    return { ready_percent: 0, missing: [...REQUIRED_FIELDS] };
   }
 
-  if (typeof audit.ready_percent !== "number") {
-    missing.push("ready_percent");
-  }
-  if (!Array.isArray(audit.issues)) {
-    missing.push("issues");
+  for (const field of REQUIRED_FIELDS) {
+    const value = (report as any)[field];
+    const isMissing =
+      value === undefined ||
+      value === null ||
+      (typeof value === "string" && !value.trim()) ||
+      (Array.isArray(value) && value.length === 0);
+    if (isMissing) missing.push(field);
   }
 
-  return {
-    ready_percent: typeof audit.ready_percent === "number" ? audit.ready_percent : 0,
-    missing
-  };
+  const ready_percent = Math.round(
+    ((REQUIRED_FIELDS.length - missing.length) / REQUIRED_FIELDS.length) * 100
+  );
+
+  return { ready_percent, missing };
 }

--- a/test/gates.test.ts
+++ b/test/gates.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { runGates } from '../src/lib/workflow';
+
+test('runGates detects missing fields', () => {
+  const result = runGates({ secretary: { audit: { summary: 'A', equations: ['E=mc^2'] } } });
+  assert.strictEqual(result.ready_percent, 67);
+  assert.deepStrictEqual(result.missing, ['references']);
+});
+
+test('runGates passes when all fields present', () => {
+  const result = runGates({ secretary: { audit: { summary: 'A', equations: ['E=mc^2'], references: ['Ref'] } } });
+  assert.strictEqual(result.ready_percent, 100);
+  assert.deepStrictEqual(result.missing, []);
+});


### PR DESCRIPTION
## Summary
- require summary, equations and references in secretary gate
- add tests for gate behavior

## Testing
- `npm test` *(fails: jest not found)*
- `node --test` *(fails: test code failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a05d99673c832188dc115df4e2c7fb