### PR TITLE
feat: expand secretary and planning workflows

### DIFF
--- a/src/lib/workers/researchSecretary.ts
+++ b/src/lib/workers/researchSecretary.ts
@@ -3,9 +3,10 @@ import path from "path";
 import { createInterface } from "readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 
-export interface CriterionPlan {
-  criterion: string;
-  plan: string;
+export interface QN21PlanItem {
+  item: string;
+  priority: string;
+  qn: string;
 }
 
 /**
@@ -15,30 +16,41 @@ export interface CriterionPlan {
  */
 export async function runResearchSecretary(
   name: string,
-  criteria?: CriterionPlan[]
+  items?: QN21PlanItem[]
 ) {
   const safeName = name.replace(/[^a-z0-9_-]/gi, "_");
 
-  let plans: CriterionPlan[] = criteria ?? [];
-  if (!criteria) {
+  let plans: QN21PlanItem[] = items ?? [];
+  if (!items) {
     const rl = createInterface({ input, output });
     try {
-      const countStr = await rl.question("Number of criteria: ");
+      const countStr = await rl.question("Number of items: ");
       const count = Math.max(0, parseInt(countStr, 10) || 0);
       for (let i = 0; i < count; i++) {
-        const criterion = await rl.question(`Criterion ${i + 1}: `);
-        const plan = await rl.question(`Plan for ${criterion}: `);
-        plans.push({ criterion, plan });
+        const item = await rl.question(`Item ${i + 1}: `);
+        const priority = await rl.question(`Priority for ${item}: `);
+        const qn = await rl.question(`QN-21 criterion for ${item}: `);
+        plans.push({ item, priority, qn });
       }
     } finally {
       rl.close();
     }
   }
 
-  const sections = plans
-    .map((p) => [`## ${p.criterion}`, p.plan])
-    .flat();
-  const content = ["# Plan for " + safeName, "", ...sections, ""].join("\n");
+  const header = [
+    "| Item | Priority | QN-21 Criterion |",
+    "|------|----------|-----------------|",
+  ];
+  const rows = plans.map(
+    (p) => `| ${p.item} | ${p.priority} | ${p.qn} |`
+  );
+  const content = [
+    "# Plan for " + safeName,
+    "",
+    ...header,
+    ...rows,
+    "",
+  ].join("\n");
 
   const filePath = path.join(process.cwd(), "paper", `plan-${safeName}.md`);
   await mkdir(path.dirname(filePath), { recursive: true });

--- a/src/lib/workers/secretary.ts
+++ b/src/lib/workers/secretary.ts
@@ -5,8 +5,9 @@ import { stdin as input, stdout as output } from "node:process";
 
 export interface SecretaryData {
   summary: string;
-  conditions: string;
+  conditions: string[];
   equations: string[];
+  references: string[];
 }
 
 /**
@@ -16,24 +17,38 @@ export interface SecretaryData {
  */
 export async function runSecretary(data?: SecretaryData) {
   let summary: string;
-  let conditions: string;
+  let conditions: string[];
   let equations: string[];
+  let references: string[];
 
   if (!data) {
     const rl = createInterface({ input, output });
     try {
       summary = await rl.question("Summary: ");
-      conditions = await rl.question("Conditions: ");
+      const condInput = await rl.question(
+        "Conditions (comma separated): "
+      );
+      conditions = condInput
+        .split(",")
+        .map((c) => c.trim())
+        .filter(Boolean);
       const eqInput = await rl.question("Equations (comma separated): ");
       equations = eqInput
         .split(",")
         .map((e) => e.trim())
         .filter(Boolean);
+      const refInput = await rl.question(
+        "References (comma separated): "
+      );
+      references = refInput
+        .split(",")
+        .map((r) => r.trim())
+        .filter(Boolean);
     } finally {
       rl.close();
     }
   } else {
-    ({ summary, conditions, equations } = data);
+    ({ summary, conditions, equations, references } = data);
   }
 
   const content = [
@@ -43,10 +58,13 @@ export async function runSecretary(data?: SecretaryData) {
     summary,
     "",
     "## Conditions",
-    conditions,
+    ...conditions.map((c) => `- ${c}`),
     "",
     "## Equations",
     ...equations.map((e) => `- ${e}`),
+    "",
+    "## References",
+    ...references.map((r) => `- ${r}`),
     "",
   ].join("\n");
 

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -1,20 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { mkdtemp } from 'node:fs/promises';
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
-import { runSecretary, runResearchSecretary } from '../src/lib/workers';
+import { runSecretary, runResearchSecretary } from '../src/lib/workers/index.ts';
 
 const sampleSecretary = {
   summary: 'Project overview',
-  conditions: 'All prerequisites must be met',
-  equations: ['E=mc^2', 'a^2 + b^2 = c^2']
+  conditions: ['All prerequisites must be met', 'Environment ready'],
+  equations: ['E=mc^2', 'a^2 + b^2 = c^2'],
+  references: ['Einstein 1905', 'Pythagoras'],
 };
 
-const sampleCriteria = [
-  { criterion: 'performance', plan: 'Optimize algorithms' },
-  { criterion: 'usability', plan: 'Improve interface' }
+const samplePlan = [
+  { item: 'استكمال الاشتقاق', priority: 'P0', qn: 'QN-21-1' },
+  { item: 'تحسين الواجهة', priority: 'P2', qn: 'QN-21-8' },
 ];
 
 test('runSecretary generates a complete secretary.md', async () => {
@@ -27,25 +27,45 @@ test('runSecretary generates a complete secretary.md', async () => {
     const fileContent = await readFile(filePath, 'utf8');
     assert.strictEqual(fileContent, content);
     assert.match(fileContent, /## Summary\nProject overview/);
-    assert.match(fileContent, /## Conditions\nAll prerequisites must be met/);
-    assert.match(fileContent, /## Equations\n- E=mc\^2\n- a\^2 \+ b\^2 = c\^2/);
+    assert.match(
+      fileContent,
+      /## Conditions\n- All prerequisites must be met\n- Environment ready/
+    );
+    assert.match(
+      fileContent,
+      /## Equations\n- E=mc\^2\n- a\^2 \+ b\^2 = c\^2/
+    );
+    assert.match(
+      fileContent,
+      /## References\n- Einstein 1905\n- Pythagoras/
+    );
   } finally {
     process.chdir(prev);
   }
 });
 
-test('runResearchSecretary writes plan files with criteria sections', async () => {
+test('runResearchSecretary writes plan files with QN-21 table', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
   const prev = process.cwd();
   process.chdir(dir);
   try {
-    const { name, content } = await runResearchSecretary('alpha', sampleCriteria);
+    const { name, content } = await runResearchSecretary('alpha', samplePlan);
     const filePath = path.join(dir, 'paper', `plan-${name}.md`);
     const fileContent = await readFile(filePath, 'utf8');
     assert.strictEqual(fileContent, content);
     assert.match(fileContent, /# Plan for alpha/);
-    assert.match(fileContent, /## performance\nOptimize algorithms/);
-    assert.match(fileContent, /## usability\nImprove interface/);
+    assert.match(
+      fileContent,
+      /\| Item \| Priority \| QN-21 Criterion \|\n\|------\|----------\|-----------------\|/
+    );
+    assert.match(
+      fileContent,
+      /\| استكمال الاشتقاق \| P0 \| QN-21-1 \|/
+    );
+    assert.match(
+      fileContent,
+      /\| تحسين الواجهة \| P2 \| QN-21-8 \|/
+    );
   } finally {
     process.chdir(prev);
   }


### PR DESCRIPTION
## Summary
- extend secretary workflow to capture conditions, equations, and references
- add research secretary planner that outputs QN-21 compliant tables
- add integration test covering new file structures

## Testing
- `node --experimental-strip-types --test test/secretary-workflow.test.ts` (fails: Cannot find module '/workspace/qaadi-live/src/lib/workers/secretary')

------
https://chatgpt.com/codex/tasks/task_e_68a05d9a9cf083218120b415111dc260