### PR TITLE
feat: add custom evaluation criteria

### DIFF
--- a/src/app/api/criteria/route.ts
+++ b/src/app/api/criteria/route.ts
@@ -1,0 +1,86 @@
+import type { NextRequest } from "next/server";
+import {
+  loadCriteria,
+  addCriterion,
+  updateCriterion,
+  deleteCriterion,
+} from "../../../lib/criteria";
+
+export const runtime = "nodejs";
+
+const headers = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+  "X-Content-Type-Options": "nosniff",
+  "Access-Control-Allow-Origin": "*",
+};
+
+export async function GET() {
+  const criteria = await loadCriteria();
+  return new Response(JSON.stringify(criteria), { status: 200, headers });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { id, description, weight, keywords, enabled = true } = await req.json();
+    if (
+      !id ||
+      typeof description !== "string" ||
+      typeof weight !== "number" ||
+      !Array.isArray(keywords)
+    ) {
+      return new Response(JSON.stringify({ error: "invalid_params" }), {
+        status: 400,
+        headers,
+      });
+    }
+    const criteria = await addCriterion({ id, description, weight, keywords, enabled });
+    const added = criteria.find((c) => c.id === id);
+    return new Response(JSON.stringify(added), { status: 201, headers });
+  } catch {
+    return new Response(JSON.stringify({ error: "invalid_params" }), {
+      status: 400,
+      headers,
+    });
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  try {
+    const { id, ...updates } = await req.json();
+    if (!id) {
+      return new Response(JSON.stringify({ error: "missing_id" }), {
+        status: 400,
+        headers,
+      });
+    }
+    const criteria = await updateCriterion(id, updates);
+    const updated = criteria.find((c) => c.id === id);
+    return new Response(JSON.stringify(updated), { status: 200, headers });
+  } catch {
+    return new Response(JSON.stringify({ error: "not_found" }), {
+      status: 404,
+      headers,
+    });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    const { id } = await req.json();
+    if (!id) {
+      return new Response(JSON.stringify({ error: "missing_id" }), {
+        status: 400,
+        headers,
+      });
+    }
+    await deleteCriterion(id);
+    return new Response(JSON.stringify({ ok: true }), { status: 200, headers });
+  } catch {
+    return new Response(JSON.stringify({ error: "not_found" }), {
+      status: 404,
+      headers,
+    });
+  }
+}
+

--- a/src/lib/criteria.ts
+++ b/src/lib/criteria.ts
@@ -1,0 +1,94 @@
+import { readFile, writeFile, mkdir } from "fs/promises";
+import path from "path";
+
+export interface Criterion {
+  /** Unique identifier for the criterion */
+  id: string;
+  /** Human readable description */
+  description: string;
+  /** Weight used when computing scores */
+  weight: number;
+  /** Keywords that indicate the criterion is satisfied */
+  keywords: string[];
+  /** Whether the criterion is active */
+  enabled: boolean;
+  /** Version number for this criterion */
+  version: number;
+}
+
+export interface CriterionResult extends Criterion {
+  /** Score obtained for the criterion */
+  score: number;
+  /** Remaining points to reach the full weight */
+  gap: number;
+}
+
+const BASE = path.join(process.cwd(), "QaadiVault", "criteria");
+const LATEST = path.join(BASE, "latest.json");
+const ARCHIVE = path.join(BASE, "archive");
+
+async function ensureDirs() {
+  await mkdir(ARCHIVE, { recursive: true });
+}
+
+export async function loadCriteria(): Promise<Criterion[]> {
+  try {
+    const raw = await readFile(LATEST, "utf-8");
+    return JSON.parse(raw) as Criterion[];
+  } catch {
+    return [];
+  }
+}
+
+async function archive(criteria: Criterion[]) {
+  const ts = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
+  await writeFile(path.join(ARCHIVE, `${ts}.json`), JSON.stringify(criteria, null, 2));
+}
+
+export async function saveCriteria(criteria: Criterion[]): Promise<void> {
+  await ensureDirs();
+  await writeFile(LATEST, JSON.stringify(criteria, null, 2));
+  await archive(criteria);
+}
+
+export async function addCriterion(c: Omit<Criterion, "version">): Promise<Criterion[]> {
+  const criteria = await loadCriteria();
+  criteria.push({ ...c, version: 1 });
+  await saveCriteria(criteria);
+  return criteria;
+}
+
+export async function updateCriterion(
+  id: string,
+  updates: Partial<Omit<Criterion, "id" | "version">>
+): Promise<Criterion[]> {
+  const criteria = await loadCriteria();
+  const idx = criteria.findIndex((c) => c.id === id);
+  if (idx === -1) throw new Error("not_found");
+  const version = criteria[idx].version + 1;
+  criteria[idx] = { ...criteria[idx], ...updates, version };
+  await saveCriteria(criteria);
+  return criteria;
+}
+
+export async function deleteCriterion(id: string): Promise<Criterion[]> {
+  const criteria = await loadCriteria();
+  const next = criteria.filter((c) => c.id !== id);
+  await saveCriteria(next);
+  return next;
+}
+
+export function evaluateCriteria(
+  text: string,
+  criteria: Criterion[]
+): CriterionResult[] {
+  const lower = text.toLowerCase();
+  return criteria.map((c) => {
+    const score =
+      c.enabled && c.keywords.some((k) => lower.includes(k.toLowerCase()))
+        ? c.weight
+        : 0;
+    return { ...c, score, gap: c.weight - score };
+  });
+}
+

--- a/test/customCriteria.test.ts
+++ b/test/customCriteria.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert';
+import {
+  loadCriteria,
+  addCriterion,
+  updateCriterion,
+  deleteCriterion,
+  evaluateCriteria
+} from '../src/lib/criteria';
+
+test('CRUD and evaluation for custom criteria', async () => {
+  const start = await loadCriteria();
+  await addCriterion({
+    id: 'TST',
+    description: 'Test criterion',
+    weight: 2,
+    keywords: ['foo'],
+    enabled: true
+  });
+  let criteria = await loadCriteria();
+  let result = evaluateCriteria('foo', criteria);
+  let crit = result.find((c) => c.id === 'TST');
+  assert.ok(crit);
+  assert.strictEqual(crit?.score, 2);
+
+  await updateCriterion('TST', { enabled: false });
+  criteria = await loadCriteria();
+  result = evaluateCriteria('foo', criteria);
+  crit = result.find((c) => c.id === 'TST');
+  assert.ok(crit);
+  assert.strictEqual(crit?.score, 0);
+
+  await deleteCriterion('TST');
+  const end = await loadCriteria();
+  assert.deepStrictEqual(end, start);
+});


### PR DESCRIPTION
## Summary
- add library for custom evaluation criteria with versioned storage and evaluation helpers
- expose CRUD HTTP endpoints to manage custom criteria
- cover custom criteria workflow with a Jest test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a05d9864808321a8646b6d3408fe0e