### PR TITLE
test: verify template endpoint content

### DIFF
--- a/test/templates-endpoint.test.ts
+++ b/test/templates-endpoint.test.ts
@@ -2,10 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { NextRequest } from 'next/server';
 import { GET } from '../src/app/api/templates/route';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 
 const base = 'http://localhost/api/templates';
 
 const files = ['secretary.md', 'judge.json', 'plan.md', 'comparison.md'];
+const templatesDir = path.join(process.cwd(), 'templates');
 
 for (const name of files) {
   test(`serves ${name} with no-store header`, async () => {
@@ -14,7 +17,9 @@ for (const name of files) {
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.headers.get('Cache-Control'), 'no-store');
     const body = await res.text();
-    assert.strictEqual(body, '');
+    assert.ok(body.length > 0);
+    const expected = await readFile(path.join(templatesDir, name), 'utf8');
+    assert.strictEqual(body, expected);
   });
 }
 


### PR DESCRIPTION
## Summary
- ensure templates endpoint responses are non-empty and match stored template files

## Testing
- `npm test` *(fails: jest: not found)*
- `node --test test/templates-endpoint.test.ts` *(fails: cannot find package 'next')*


------
https://chatgpt.com/codex/tasks/task_e_68a0796ed7648321935bda6f2b9c9207