### PR TITLE
Use next/jest with jsdom test environment

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,13 @@
-export default {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+import nextJest from 'next/jest.js';
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
 };
+
+export default createJestConfig(config);
+


### PR DESCRIPTION
## Summary
- configure Jest with `next/jest`
- run component tests in a jsdom environment

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0796de80883218c9e1b0eda4d74a4