### PR TITLE
chore: migrate tests to jest

### DIFF
--- a/test/advisor.test.ts
+++ b/test/advisor.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { generateInquiryFromPlan } from '../src/lib/utils/inquiry';
 
 const samplePlan = `- Define scope
@@ -7,8 +6,8 @@ const samplePlan = `- Define scope
 
 test('generateInquiryFromPlan creates questions with covers', () => {
   const { markdown, questions } = generateInquiryFromPlan(samplePlan, 'en');
-  assert.strictEqual(questions.length, 2);
-  assert(markdown.includes('1.'));
-  assert(questions[0].covers[0]);
-  assert(questions[0].question.includes('Define scope'));
+  expect(questions.length).toBe(2);
+  expect(markdown).toContain('1.');
+  expect(questions[0].covers[0]).toBeTruthy();
+  expect(questions[0].question).toContain('Define scope');
 });

--- a/test/customCriteria.test.ts
+++ b/test/customCriteria.test.ts
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import {
   loadCriteria,
   addCriterion,
@@ -19,17 +19,17 @@ test('CRUD and evaluation for custom criteria', async () => {
   let criteria = await loadCriteria();
   let result = evaluateCriteria('foo', criteria);
   let crit = result.find((c) => c.id === 'TST');
-  assert.ok(crit);
-  assert.strictEqual(crit?.score, 2);
+  expect(crit).toBeTruthy();
+  expect(crit?.score).toBe(2);
 
   await updateCriterion('TST', { enabled: false });
   criteria = await loadCriteria();
   result = evaluateCriteria('foo', criteria);
   crit = result.find((c) => c.id === 'TST');
-  assert.ok(crit);
-  assert.strictEqual(crit?.score, 0);
+  expect(crit).toBeTruthy();
+  expect(crit?.score).toBe(0);
 
   await deleteCriterion('TST');
   const end = await loadCriteria();
-  assert.deepStrictEqual(end, start);
+  expect(end).toEqual(start);
 });

--- a/test/download-zip.test.ts
+++ b/test/download-zip.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect, beforeAll, afterAll } from '@jest/globals';
 import { GET } from '../src/app/api/download/zip/route';
 import { NextRequest } from 'next/server';
 import { mkdir, writeFile, rm, cp } from 'node:fs/promises';
@@ -8,7 +7,7 @@ import crypto from 'node:crypto';
 
 const root = process.cwd();
 
-test.before(async () => {
+beforeAll(async () => {
   const srcDB = path.join(root, 'test', 'data', 'QaadiDB');
   const destDB = path.join(root, 'QaadiDB');
   await cp(srcDB, destDB, { recursive: true });
@@ -18,7 +17,7 @@ test.before(async () => {
   await cp(srcVault, destVault, { recursive: true });
 });
 
-test.after(async () => {
+afterAll(async () => {
   await rm(path.join(root, 'QaadiDB'), { recursive: true, force: true });
   await rm(path.join(root, 'QaadiVault'), { recursive: true, force: true });
 });
@@ -44,13 +43,13 @@ function unzipStore(u8: Uint8Array): Record<string, Uint8Array> {
 test('determinism and provenance non-empty', async () => {
   const req = new NextRequest('http://localhost/api/download/zip?slug=demo&v=v1.0');
   const res = await GET(req);
-  assert.strictEqual(res.status, 200);
+  expect(res.status).toBe(200);
   const buf = Buffer.from(await res.arrayBuffer());
   const files = unzipStore(buf);
   const determinism = JSON.parse(Buffer.from(files['determinism_matrix.json']).toString());
   const provenance = JSON.parse(Buffer.from(files['provenance.json']).toString());
-  assert.ok(Array.isArray(determinism.matrix) && determinism.matrix.length > 0);
-  assert.ok(Array.isArray(provenance.sources) && provenance.sources.length > 0);
+  expect(Array.isArray(determinism.matrix) && determinism.matrix.length > 0).toBeTruthy();
+  expect(Array.isArray(provenance.sources) && provenance.sources.length > 0).toBeTruthy();
 });
 
 test('reads snapshots manifest, filters by slug/version and uses v6 archive name', async () => {
@@ -66,24 +65,24 @@ test('reads snapshots manifest, filters by slug/version and uses v6 archive name
 
   const req1 = new NextRequest('http://localhost/api/download/zip?slug=demo&v=v1.0');
   const res1 = await GET(req1);
-  assert.strictEqual(res1.status, 200);
+  expect(res1.status).toBe(200);
   const disp = res1.headers.get('Content-Disposition');
-  assert.ok(disp && /attachment; filename="qaadi_v6_demo_v1\.0_\d{14}\.zip"/.test(disp));
+  expect(disp && /attachment; filename="qaadi_v6_demo_v1\.0_\d{14}\.zip"/.test(disp!)).toBeTruthy();
   const buf1 = Buffer.from(await res1.arrayBuffer());
   const files1 = unzipStore(buf1);
   const determinism1 = JSON.parse(Buffer.from(files1['determinism_matrix.json']).toString());
-  assert.deepStrictEqual(determinism1.matrix, [
+  expect(determinism1.matrix).toEqual([
     [1, 0],
     [0, 1]
   ]);
 
   const req2 = new NextRequest('http://localhost/api/download/zip?slug=demo&v=v2.0');
   const res2 = await GET(req2);
-  assert.strictEqual(res2.status, 200);
+  expect(res2.status).toBe(200);
   const buf2 = Buffer.from(await res2.arrayBuffer());
   const files2 = unzipStore(buf2);
   const determinism2 = JSON.parse(Buffer.from(files2['determinism_matrix.json']).toString());
-  assert.deepStrictEqual(determinism2.matrix, [[1]]);
+  expect(determinism2.matrix).toEqual([[1]]);
 
   await rm(path.join(dir, 'manifest.json'));
 });
@@ -121,11 +120,11 @@ test('includes latest snapshot files in archive', async () => {
 
   const req = new NextRequest('http://localhost/api/download/zip?slug=demo&v=v1.0');
   const res = await GET(req);
-  assert.strictEqual(res.status, 200);
+  expect(res.status).toBe(200);
   const buf = Buffer.from(await res.arrayBuffer());
   const files = unzipStore(buf);
-  assert.ok(files['paper/revtex/en/draft.tex']);
-  assert.ok(files['paper/revtex/en/secretary.md']);
+  expect(files['paper/revtex/en/draft.tex']).toBeTruthy();
+  expect(files['paper/revtex/en/secretary.md']).toBeTruthy();
 
   await rm(path.join(root, 'public', 'snapshots'), { recursive: true, force: true });
 });

--- a/test/editor-disabled.test.ts
+++ b/test/editor-disabled.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import Editor from '../src/components/Editor';
@@ -7,9 +6,9 @@ import Editor from '../src/components/Editor';
 test('export and generate buttons require target and lang', () => {
   // initial render without target/lang -> buttons disabled
   const initial = renderToStaticMarkup(React.createElement(Editor));
-  assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
-  assert.match(initial, /<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
-  assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
+  expect(initial).toMatch(/<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
+  expect(initial).toMatch(/<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
+  expect(initial).toMatch(/<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
 
   // render with target and lang preset -> buttons enabled
   const origUseState = React.useState;
@@ -23,7 +22,7 @@ test('export and generate buttons require target and lang', () => {
   const withValues = renderToStaticMarkup(React.createElement(Editor));
   (React as any).useState = origUseState;
 
-  assert.doesNotMatch(withValues, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
-  assert.doesNotMatch(withValues, /<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
-  assert.doesNotMatch(withValues, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
+  expect(withValues).not.toMatch(/<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
+  expect(withValues).not.toMatch(/<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
+  expect(withValues).not.toMatch(/<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
 });

--- a/test/gates.test.ts
+++ b/test/gates.test.ts
@@ -1,15 +1,14 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { runGates } from '../src/lib/workflow';
 
 test('runGates detects missing fields', () => {
   const result = runGates({ secretary: { audit: { summary: 'A', equations: ['E=mc^2'] } } });
-  assert.strictEqual(result.ready_percent, 67);
-  assert.deepStrictEqual(result.missing, ['references']);
+  expect(result.ready_percent).toBe(67);
+  expect(result.missing).toEqual(['references']);
 });
 
 test('runGates passes when all fields present', () => {
   const result = runGates({ secretary: { audit: { summary: 'A', equations: ['E=mc^2'], references: ['Ref'] } } });
-  assert.strictEqual(result.ready_percent, 100);
-  assert.deepStrictEqual(result.missing, []);
+  expect(result.ready_percent).toBe(100);
+  expect(result.missing).toEqual([]);
 });

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,25 +1,22 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { GET } from '../src/app/api/health/route';
 
 // Ensure the health endpoint exposes the complete diagnostic schema.
 test('health endpoint exposes policies, storage, kv, and capsule fields', async () => {
   const res = await GET();
-  assert.strictEqual(res.status, 200);
+  expect(res.status).toBe(200);
   const body = await res.json();
 
-  assert.deepStrictEqual(body.policies, {
+  expect(body.policies).toEqual({
     byok: true,
     storage_public_read_capsules: true,
     storage_public_read_theory_zips: true
   });
 
-  assert.ok('storage' in body);
-  assert.ok('kv' in body);
-  assert.ok(
-    body.capsule &&
-      'name' in body.capsule &&
-      'sha256' in body.capsule &&
-      'ts' in body.capsule
-  );
+  expect(body).toHaveProperty('storage');
+  expect(body).toHaveProperty('kv');
+  expect(body.capsule).toBeTruthy();
+  expect(body.capsule).toHaveProperty('name');
+  expect(body.capsule).toHaveProperty('sha256');
+  expect(body.capsule).toHaveProperty('ts');
 });

--- a/test/inquiry.test.ts
+++ b/test/inquiry.test.ts
@@ -1,18 +1,13 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { buildPrompt } from '../src/lib/buildPrompt';
 
 test('buildPrompt handles inquiry in English', () => {
   const { prompt } = buildPrompt('inquiry', 'en', 'What is the role of Qaadi?', null);
-  assert.strictEqual(
-    prompt,
+  expect(prompt).toBe(
     'INQUIRY/EN: You are the Qaadi engine. Answer an English inquiry intended for the paper (inquiry.md). Input:\nWhat is the role of Qaadi?'
   );
 });
 
 test('buildPrompt rejects unsupported inquiry language', () => {
-  assert.throws(
-    () => buildPrompt('inquiry', 'other', 'Hello', null),
-    /unsupported_inquiry_lang/
-  );
+  expect(() => buildPrompt('inquiry', 'other', 'Hello', null)).toThrow(/unsupported_inquiry_lang/);
 });

--- a/test/manifest-filter.test.ts
+++ b/test/manifest-filter.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { latestFilesFor, ManifestEntry } from '../src/lib/utils/manifest';
 
 test('returns only files from requested version', () => {
@@ -10,5 +9,5 @@ test('returns only files from requested version', () => {
     { slug: 'demo', v: 'v2', timestamp: '20240104T000000', path: 'v2/latest.md' },
   ];
   const files = latestFilesFor(manifest, 'demo', 'v2');
-  assert.deepStrictEqual(files, ['v2/latest.md']);
+  expect(files).toEqual(['v2/latest.md']);
 });

--- a/test/no-export-get-link.test.ts
+++ b/test/no-export-get-link.test.ts
@@ -1,10 +1,9 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import Editor from '../src/components/Editor';
 
 test('editor has no direct GET export link', () => {
   const markup = renderToStaticMarkup(React.createElement(Editor));
-  assert.doesNotMatch(markup, /<a[^>]+href="\/api\/export"/);
+  expect(markup).not.toMatch(/<a[^>]+href="\/api\/export"/);
 });

--- a/test/q21.test.ts
+++ b/test/q21.test.ts
@@ -1,4 +1,4 @@
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 
 import { evaluateQN21, QN21_CRITERIA, summarizeQN21 } from '../src/lib/q21';
 
@@ -7,27 +7,27 @@ test('evaluateQN21 returns scores and gaps based on keywords', () => {
     'The equation F = ma was derived with rigorous analysis and ethical oversight.';
   const result = evaluateQN21(text);
 
-  assert.strictEqual(result.length, QN21_CRITERIA.length);
+  expect(result.length).toBe(QN21_CRITERIA.length);
 
   const equations = result.find((r) => r.code === 'equations');
-  assert.ok(equations);
-  assert.strictEqual(equations?.score, 8);
-  assert.strictEqual(equations?.gap, 0);
+  expect(equations).toBeTruthy();
+  expect(equations?.score).toBe(8);
+  expect(equations?.gap).toBe(0);
 
   const rigor = result.find((r) => r.code === 'rigor');
-  assert.ok(rigor);
-  assert.strictEqual(rigor?.score, 6);
-  assert.strictEqual(rigor?.gap, 0);
+  expect(rigor).toBeTruthy();
+  expect(rigor?.score).toBe(6);
+  expect(rigor?.gap).toBe(0);
 
   const ethics = result.find((r) => r.code === 'ethics');
-  assert.ok(ethics);
-  assert.strictEqual(ethics?.score, 8);
-  assert.strictEqual(ethics?.gap, 0);
+  expect(ethics).toBeTruthy();
+  expect(ethics?.score).toBe(8);
+  expect(ethics?.gap).toBe(0);
 
   const safety = result.find((r) => r.code === 'safety');
-  assert.ok(safety);
-  assert.strictEqual(safety?.score, 0);
-  assert.strictEqual(safety?.gap, 5);
+  expect(safety).toBeTruthy();
+  expect(safety?.score).toBe(0);
+  expect(safety?.gap).toBe(5);
 });
 
 test('evaluateQN21 handles partial criteria in text', () => {
@@ -36,16 +36,16 @@ test('evaluateQN21 handles partial criteria in text', () => {
   const result = evaluateQN21(text);
 
   const calibration = result.find((r) => r.code === 'calibration');
-  assert.ok(calibration);
-  assert.strictEqual(calibration?.score, 3);
+  expect(calibration).toBeTruthy();
+  expect(calibration?.score).toBe(3);
 
   const reproducibility = result.find((r) => r.code === 'reproducibility');
-  assert.ok(reproducibility);
-  assert.strictEqual(reproducibility?.score, 0);
+  expect(reproducibility).toBeTruthy();
+  expect(reproducibility?.score).toBe(0);
 
   const engagement = result.find((r) => r.code === 'engagement');
-  assert.ok(engagement);
-  assert.strictEqual(engagement?.score, 5);
+  expect(engagement).toBeTruthy();
+  expect(engagement?.score).toBe(5);
 });
 
 test('summarizeQN21 computes percentage and classification', () => {
@@ -54,9 +54,9 @@ test('summarizeQN21 computes percentage and classification', () => {
     .join(' ');
   const result = evaluateQN21(text);
   const summary = summarizeQN21(result);
-  assert.strictEqual(summary.total, 17);
-  assert.strictEqual(summary.max, QN21_CRITERIA.length);
-  assert.ok(summary.percentage > 80);
-  assert.strictEqual(summary.classification, 'accepted');
+  expect(summary.total).toBe(17);
+  expect(summary.max).toBe(QN21_CRITERIA.length);
+  expect(summary.percentage > 80).toBeTruthy();
+  expect(summary.classification).toBe('accepted');
 });
 

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { mkdtemp, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
@@ -25,20 +24,17 @@ test('runSecretary generates a complete secretary.md', async () => {
     const content = await runSecretary(sampleSecretary);
     const filePath = path.join(dir, 'paper', 'secretary.md');
     const fileContent = await readFile(filePath, 'utf8');
-    assert.strictEqual(fileContent, content);
-    assert.match(fileContent, /## Summary\nProject overview/);
-    assert.match(
-      fileContent,
-      /## Conditions\n- All prerequisites must be met\n- Environment ready/
-    );
-    assert.match(
-      fileContent,
-      /## Equations\n- E=mc\^2\n- a\^2 \+ b\^2 = c\^2/
-    );
-    assert.match(
-      fileContent,
-      /## References\n- Einstein 1905\n- Pythagoras/
-    );
+    expect(fileContent).toBe(content);
+    expect(fileContent).toMatch(/## Summary\nProject overview/);
+    expect(
+      fileContent
+    ).toMatch(/## Conditions\n- All prerequisites must be met\n- Environment ready/);
+    expect(
+      fileContent
+    ).toMatch(/## Equations\n- E=mc\^2\n- a\^2 \+ b\^2 = c\^2/);
+    expect(
+      fileContent
+    ).toMatch(/## References\n- Einstein 1905\n- Pythagoras/);
   } finally {
     process.chdir(prev);
   }
@@ -52,20 +48,13 @@ test('runResearchSecretary writes plan files with QN-21 table', async () => {
     const { name, content } = await runResearchSecretary('alpha', samplePlan);
     const filePath = path.join(dir, 'paper', `plan-${name}.md`);
     const fileContent = await readFile(filePath, 'utf8');
-    assert.strictEqual(fileContent, content);
-    assert.match(fileContent, /# Plan for alpha/);
-    assert.match(
-      fileContent,
-      /\| Item \| Priority \| QN-21 Criterion \|\n\|------\|----------\|-----------------\|/
-    );
-    assert.match(
-      fileContent,
-      /\| استكمال الاشتقاق \| P0 \| QN-21-1 \|/
-    );
-    assert.match(
-      fileContent,
-      /\| تحسين الواجهة \| P2 \| QN-21-8 \|/
-    );
+    expect(fileContent).toBe(content);
+    expect(fileContent).toMatch(/# Plan for alpha/);
+    expect(
+      fileContent
+    ).toMatch(/\| Item \| Priority \| QN-21 Criterion \|\n\|------\|----------\|-----------------\|/);
+    expect(fileContent).toMatch(/\| استكمال الاشتقاق \| P0 \| QN-21-1 \|/);
+    expect(fileContent).toMatch(/\| تحسين الواجهة \| P2 \| QN-21-8 \|/);
   } finally {
     process.chdir(prev);
   }

--- a/test/snapshot-placeholder.test.ts
+++ b/test/snapshot-placeholder.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -37,10 +36,10 @@ test('placeholder files have stable fingerprints on regeneration', async () => {
   const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
   const biblio = manifest.filter((e: any) => e.path.endsWith('biblio.bib') && e.slug === 'demo' && e.v === 'v1');
   const figs = manifest.filter((e: any) => e.path.endsWith('figs/') && e.slug === 'demo' && e.v === 'v1');
-  assert.strictEqual(biblio.length, 2);
-  assert.strictEqual(figs.length, 2);
-  assert.strictEqual(new Set(biblio.map((e: any) => e.sha256)).size, 1);
-  assert.strictEqual(new Set(figs.map((e: any) => e.sha256)).size, 1);
+  expect(biblio.length).toBe(2);
+  expect(figs.length).toBe(2);
+  expect(new Set(biblio.map((e: any) => e.sha256)).size).toBe(1);
+  expect(new Set(figs.map((e: any) => e.sha256)).size).toBe(1);
 });
 
 test('saves role files with type role', async () => {
@@ -57,5 +56,5 @@ test('saves role files with type role', async () => {
   const manifestPath = path.join(dir, 'public', 'snapshots', 'manifest.json');
   const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
   const role = manifest.find((e: any) => e.path.endsWith('secretary.md'));
-  assert.ok(role && role.type === 'role');
+  expect(role?.type).toBe('role');
 });

--- a/test/templates-endpoint.test.ts
+++ b/test/templates-endpoint.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { NextRequest } from 'next/server';
 import { GET } from '../src/app/api/templates/route';
 
@@ -11,15 +10,15 @@ for (const name of files) {
   test(`serves ${name} with no-store header`, async () => {
     const req = new NextRequest(`${base}?name=${encodeURIComponent(name)}`);
     const res = await GET(req);
-    assert.strictEqual(res.status, 200);
-    assert.strictEqual(res.headers.get('Cache-Control'), 'no-store');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
     const body = await res.text();
-    assert.strictEqual(body, '');
+    expect(body).toBe('');
   });
 }
 
 test('missing template returns 404', async () => {
   const req = new NextRequest(`${base}?name=missing.md`);
   const res = await GET(req);
-  assert.strictEqual(res.status, 404);
+  expect(res.status).toBe(404);
 });


### PR DESCRIPTION
## Summary
- replace node:test with Jest globals
- update assertions to use expect syntax

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a079707d048321a8e81808f0c04574