### PR TITLE
feat: add translation route and lang direction

### DIFF
--- a/src/components/LangDirProvider.tsx
+++ b/src/components/LangDirProvider.tsx
@@ -4,29 +4,26 @@ import { useEffect, useState } from "react";
 
 export default function LangDirProvider() {
   const [lang, setLang] = useState(
-    typeof navigator !== "undefined" ? navigator.language.split("-")[0] : ""
+    typeof navigator !== "undefined" ? navigator.language.split("-")[0] : "en"
   );
-  const [dir, setDir] = useState<"ltr" | "rtl" | "">(
-    typeof navigator !== "undefined"
-      ? navigator.language.startsWith("ar")
-        ? "rtl"
-        : "ltr"
-      : ""
-  );
+  const [dir, setDir] = useState<"ltr" | "rtl">("ltr");
 
   useEffect(() => {
     try {
       const l = localStorage.getItem("lang");
-      const d = localStorage.getItem("dir");
       if (l) setLang(l);
-      else setLang("en");
-      if (d === "rtl" || d === "ltr") setDir(d as "rtl" | "ltr");
-      else setDir("ltr");
-    } catch {
-      setLang("en");
-      setDir("ltr");
-    }
+    } catch {}
   }, []);
+
+  useEffect(() => {
+    const rtlLangs = new Set(["ar", "he", "fa", "ur"]);
+    const newDir: "ltr" | "rtl" = rtlLangs.has(lang) ? "rtl" : "ltr";
+    setDir(newDir);
+    try {
+      localStorage.setItem("lang", lang);
+      localStorage.setItem("dir", newDir);
+    } catch {}
+  }, [lang]);
 
   useEffect(() => {
     document.documentElement.lang = lang;

--- a/src/lib/buildPrompt.ts
+++ b/src/lib/buildPrompt.ts
@@ -1,5 +1,29 @@
 import { freezeText, FrozenText } from "./utils/freeze";
 
+export function buildTranslationPrompts(
+  langs: string[],
+  userText: string
+): { prompts: Record<string, string>; frozen: FrozenText } {
+  const frozen = freezeText(userText);
+  const langNames: Record<string, string> = {
+    ar: "Arabic",
+    en: "English",
+    tr: "Turkish",
+    fr: "French",
+    es: "Spanish",
+    de: "German",
+    ru: "Russian",
+    "zh-Hans": "Chinese (Simplified)",
+    ja: "Japanese"
+  };
+  const prompts: Record<string, string> = {};
+  for (const l of langs) {
+    const name = langNames[l] || l;
+    prompts[l] = `TRANSLATE/${l.toUpperCase()}: Translate the following text to ${name}. Input:\n${frozen.text}`;
+  }
+  return { prompts, frozen };
+}
+
 export function buildPrompt(
   target:
     | "wide"


### PR DESCRIPTION
## Summary
- add translation workflow in generate API supporting multilingual output
- freeze equations via new `buildTranslationPrompts`
- auto-switch document direction based on selected language

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a07a83b0208321adbce6df40ea7af9