### PR TITLE
feat: evaluate criteria in judge

### DIFF
--- a/src/lib/workers/judge.ts
+++ b/src/lib/workers/judge.ts
@@ -1,8 +1,39 @@
-import { writeFile, mkdir } from "fs/promises";
+import { writeFile, mkdir, readFile } from "fs/promises";
 import path from "path";
+import { evaluateQN21, summarizeQN21 } from "../q21";
+import { loadCriteria, evaluateCriteria } from "../criteria";
+
+function summarize(results: { score: number; weight: number }[]) {
+  const total = results.reduce((s, r) => s + r.score, 0);
+  const max = results.reduce((s, r) => s + r.weight, 0);
+  const percentage = max === 0 ? 0 : (total / max) * 100;
+  let classification: "accepted" | "needs_improvement" | "weak" = "weak";
+  if (percentage >= 80) classification = "accepted";
+  else if (percentage >= 60) classification = "needs_improvement";
+  return { total, max, percentage, classification };
+}
 
 export async function runJudge() {
-  const result = { verdict: "approved" };
+  let text = "";
+  const draftPath = path.join(process.cwd(), "paper", "draft.md");
+  try {
+    text = await readFile(draftPath, "utf8");
+  } catch {
+    /* ignore missing draft */
+  }
+
+  const qn21Results = evaluateQN21(text);
+  const qn21Summary = summarizeQN21(qn21Results);
+
+  const criteria = await loadCriteria();
+  const criteriaResults = evaluateCriteria(text, criteria);
+  const criteriaSummary = summarize(criteriaResults);
+
+  const result = {
+    qn21: { results: qn21Results, summary: qn21Summary },
+    criteria: { results: criteriaResults, summary: criteriaSummary }
+  };
+
   const filePath = path.join(process.cwd(), "paper", "judge.json");
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, JSON.stringify(result, null, 2), "utf8");

--- a/test/judge.test.ts
+++ b/test/judge.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { runJudge } from '../src/lib/workers';
+
+test('runJudge computes scores and writes judge.json', async () => {
+  const paperDir = path.join(process.cwd(), 'paper');
+  const criteriaDir = path.join(process.cwd(), 'QaadiVault', 'criteria');
+  await fs.rm(paperDir, { recursive: true, force: true });
+  await fs.rm(path.join(process.cwd(), 'QaadiVault'), { recursive: true, force: true });
+  await fs.mkdir(paperDir, { recursive: true });
+  await fs.mkdir(criteriaDir, { recursive: true });
+  await fs.writeFile(path.join(paperDir, 'draft.md'), 'This experiment used foo.');
+  const custom = [
+    { id: 'C1', description: 'mentions foo', weight: 2, keywords: ['foo'], enabled: true, version: 1 },
+    { id: 'C2', description: 'mentions bar', weight: 3, keywords: ['bar'], enabled: true, version: 1 }
+  ];
+  await fs.writeFile(path.join(criteriaDir, 'latest.json'), JSON.stringify(custom));
+
+  const res = await runJudge();
+
+  const experiment = res.qn21.results.find((r: any) => r.code === 'experiment');
+  assert.ok(experiment);
+  assert.strictEqual(experiment.score, 6);
+  assert.strictEqual(res.qn21.summary.classification, 'weak');
+
+  const c1 = res.criteria.results.find((r: any) => r.id === 'C1');
+  const c2 = res.criteria.results.find((r: any) => r.id === 'C2');
+  assert.ok(c1 && c2);
+  assert.strictEqual(c1.score, 2);
+  assert.strictEqual(c2.score, 0);
+  assert.strictEqual(res.criteria.summary.total, 2);
+  assert.strictEqual(res.criteria.summary.classification, 'weak');
+
+  const judgePath = path.join(paperDir, 'judge.json');
+  const file = await fs.readFile(judgePath, 'utf8');
+  const json = JSON.parse(file);
+  assert.deepStrictEqual(json.criteria.summary, res.criteria.summary);
+});


### PR DESCRIPTION
## Summary
- compute QN21 and custom criteria scores in `runJudge`
- persist detailed judging results to `paper/judge.json`
- add tests for judging logic and file output

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a07a7c9b408321b2f5d0587fa45842