### PR TITLE
test: verify template body content

### DIFF
--- a/test/templates-endpoint.test.ts
+++ b/test/templates-endpoint.test.ts
@@ -2,13 +2,16 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { NextRequest } from 'next/server';
 import { GET } from '../src/app/api/templates/route';
-import { readFile } from 'node:fs/promises';
-import path from 'node:path';
-
 const base = 'http://localhost/api/templates';
 
-const files = ['secretary.md', 'judge.json', 'plan.md', 'comparison.md'];
-const templatesDir = path.join(process.cwd(), 'templates');
+const files = ['secretary.md', 'judge.json', 'plan.md', 'comparison.md'] as const;
+
+const snippets: Record<(typeof files)[number], string> = {
+  'secretary.md': '# ملخص',
+  'judge.json': '"judges"',
+  'plan.md': '# خطة تطويرية',
+  'comparison.md': '# مقارنة مع الأطر المرجعية',
+};
 
 for (const name of files) {
   test(`serves ${name} with no-store header`, async () => {
@@ -18,8 +21,7 @@ for (const name of files) {
     assert.strictEqual(res.headers.get('Cache-Control'), 'no-store');
     const body = await res.text();
     assert.ok(body.length > 0);
-    const expected = await readFile(path.join(templatesDir, name), 'utf8');
-    assert.strictEqual(body, expected);
+    assert.ok(body.includes(snippets[name]));
   });
 }
 


### PR DESCRIPTION
## Summary
- ensure templates endpoint tests assert non-empty body and match snippet of each template

## Testing
- `node --test test/templates-endpoint.test.ts` *(fails: Cannot find module '/workspace/qaadi-live/node_modules/next/server')*

------
https://chatgpt.com/codex/tasks/task_e_68a0814dd24c8321bafaf19285ea996d