### PR TITLE
test: use jest expect for health policies

### DIFF
--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,25 +1,23 @@
-import test from 'node:test';
-import assert from 'node:assert';
 import { GET } from '../src/app/api/health/route';
 
 // Ensure the health endpoint exposes the complete diagnostic schema.
 test('health endpoint exposes policies, storage, kv, and capsule fields', async () => {
   const res = await GET();
-  assert.strictEqual(res.status, 200);
+  expect(res.status).toBe(200);
   const body = await res.json();
 
-  assert.deepStrictEqual(body.policies, {
+  expect(body.policies).toEqual({
     byok: true,
     storage_public_read_capsules: true,
     storage_public_read_theory_zips: true
   });
 
-  assert.ok('storage' in body);
-  assert.ok('kv' in body);
-  assert.ok(
+  expect(body).toHaveProperty('storage');
+  expect(body).toHaveProperty('kv');
+  expect(
     body.capsule &&
       'name' in body.capsule &&
       'sha256' in body.capsule &&
       'ts' in body.capsule
-  );
+  ).toBe(true);
 });


### PR DESCRIPTION
## Summary
- refactor health endpoint test to use Jest expect API for policies

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0814886888321bc6369fe7b176e3a