### PR TITLE
refactor: migrate node:test assertions to jest

### DIFF
--- a/test/advisor.test.ts
+++ b/test/advisor.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { generateInquiryFromPlan } from '../src/lib/utils/inquiry';
 
 const samplePlan = `- Define scope
@@ -7,8 +6,8 @@ const samplePlan = `- Define scope
 
 test('generateInquiryFromPlan creates questions with covers', () => {
   const { markdown, questions } = generateInquiryFromPlan(samplePlan, 'en');
-  assert.strictEqual(questions.length, 2);
-  assert(markdown.includes('1.'));
-  assert(questions[0].covers[0]);
-  assert(questions[0].question.includes('Define scope'));
+  expect(questions.length).toBe(2);
+  expect(markdown.includes('1.')).toBe(true);
+  expect(questions[0].covers[0]).toBeTruthy();
+  expect(questions[0].question).toContain('Define scope');
 });

--- a/test/consultant.test.ts
+++ b/test/consultant.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { mkdtemp, writeFile, readFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
@@ -23,9 +22,9 @@ test('runConsultant summarizes judge strengths and gaps', async () => {
     const content = await runConsultant();
     const notesPath = path.join(paperDir, 'notes.txt');
     const fileContent = await readFile(notesPath, 'utf8');
-    assert.strictEqual(content, fileContent);
-    assert.match(fileContent, /## Strengths\n- Method/);
-    assert.match(fileContent, /## Gaps\n- Data/);
+    expect(content).toBe(fileContent);
+    expect(fileContent).toMatch(/## Strengths\n- Method/);
+    expect(fileContent).toMatch(/## Gaps\n- Data/);
   } finally {
     process.chdir(prev);
   }

--- a/test/editor-disabled.test.ts
+++ b/test/editor-disabled.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import Editor from '../src/components/Editor';
@@ -7,9 +6,9 @@ import Editor from '../src/components/Editor';
 test('export and generate buttons require target and lang', () => {
   // initial render without target/lang -> buttons disabled
   const initial = renderToStaticMarkup(React.createElement(Editor));
-  assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
-  assert.match(initial, /<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
-  assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
+  expect(initial).toMatch(/<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
+  expect(initial).toMatch(/<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
+  expect(initial).toMatch(/<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
 
   // render with target and lang preset -> buttons enabled
   const origUseState = React.useState;
@@ -23,7 +22,7 @@ test('export and generate buttons require target and lang', () => {
   const withValues = renderToStaticMarkup(React.createElement(Editor));
   (React as any).useState = origUseState;
 
-  assert.doesNotMatch(withValues, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
-  assert.doesNotMatch(withValues, /<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
-  assert.doesNotMatch(withValues, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
+  expect(withValues).not.toMatch(/<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
+  expect(withValues).not.toMatch(/<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
+  expect(withValues).not.toMatch(/<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
 });

--- a/test/gates.test.ts
+++ b/test/gates.test.ts
@@ -1,15 +1,14 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { runGates } from '../src/lib/workflow';
 
 test('runGates detects missing fields', () => {
   const result = runGates({ secretary: { audit: { summary: 'A', equations: ['E=mc^2'] } } });
-  assert.strictEqual(result.ready_percent, 67);
-  assert.deepStrictEqual(result.missing, ['references']);
+  expect(result.ready_percent).toBe(67);
+  expect(result.missing).toEqual(['references']);
 });
 
 test('runGates passes when all fields present', () => {
   const result = runGates({ secretary: { audit: { summary: 'A', equations: ['E=mc^2'], references: ['Ref'] } } });
-  assert.strictEqual(result.ready_percent, 100);
-  assert.deepStrictEqual(result.missing, []);
+  expect(result.ready_percent).toBe(100);
+  expect(result.missing).toEqual([]);
 });

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -1,25 +1,24 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { GET } from '../src/app/api/health/route';
 
 // Ensure the health endpoint exposes the complete diagnostic schema.
 test('health endpoint exposes policies, storage, kv, and capsule fields', async () => {
   const res = await GET();
-  assert.strictEqual(res.status, 200);
+  expect(res.status).toBe(200);
   const body = await res.json();
 
-  assert.deepStrictEqual(body.policies, {
+  expect(body.policies).toEqual({
     byok: true,
     storage_public_read_capsules: true,
     storage_public_read_theory_zips: true
   });
 
-  assert.ok('storage' in body);
-  assert.ok('kv' in body);
-  assert.ok(
+  expect('storage' in body).toBe(true);
+  expect('kv' in body).toBe(true);
+  expect(
     body.capsule &&
       'name' in body.capsule &&
       'sha256' in body.capsule &&
       'ts' in body.capsule
-  );
+  ).toBe(true);
 });

--- a/test/inquiry.test.ts
+++ b/test/inquiry.test.ts
@@ -1,18 +1,13 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { buildPrompt } from '../src/lib/buildPrompt';
 
 test('buildPrompt handles inquiry in English', () => {
   const { prompt } = buildPrompt('inquiry', 'en', 'What is the role of Qaadi?', null);
-  assert.strictEqual(
-    prompt,
+  expect(prompt).toBe(
     'INQUIRY/EN: You are the Qaadi engine. Answer an English inquiry intended for the paper (inquiry.md). Input:\nWhat is the role of Qaadi?'
   );
 });
 
 test('buildPrompt rejects unsupported inquiry language', () => {
-  assert.throws(
-    () => buildPrompt('inquiry', 'other', 'Hello', null),
-    /unsupported_inquiry_lang/
-  );
+  expect(() => buildPrompt('inquiry', 'other', 'Hello', null)).toThrow(/unsupported_inquiry_lang/);
 });

--- a/test/journalist.test.ts
+++ b/test/journalist.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { mkdtemp, writeFile, readFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
@@ -26,9 +25,9 @@ test('runJournalist creates multilingual summaries and reports', async () => {
     ];
     for (const f of files) {
       const fc = await readFile(path.join(paperDir, f), 'utf8');
-      assert.match(fc, /E=mc\^2/);
+      expect(fc).toMatch(/E=mc\^2/);
     }
-    assert.strictEqual(content, await readFile(path.join(paperDir, 'summary.md'), 'utf8'));
+    expect(content).toBe(await readFile(path.join(paperDir, 'summary.md'), 'utf8'));
   } finally {
     process.chdir(prev);
   }

--- a/test/lead.test.ts
+++ b/test/lead.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { mkdtemp, writeFile, readFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
@@ -22,11 +21,11 @@ test('runLead merges plans and highlights best items', async () => {
     const content = await runLead(['alpha', 'beta']);
     const cmpPath = path.join(paperDir, 'comparison.md');
     const fileContent = await readFile(cmpPath, 'utf8');
-    assert.strictEqual(content, fileContent);
-    assert.match(fileContent, /# Comparison/);
-    assert.match(fileContent, /## Best Items\n- Task A \(alpha, beta\)\n- Task C \(beta\)/);
-    assert.match(fileContent, /## alpha/);
-    assert.match(fileContent, /## beta/);
+    expect(content).toBe(fileContent);
+    expect(fileContent).toMatch(/# Comparison/);
+    expect(fileContent).toMatch(/## Best Items\n- Task A \(alpha, beta\)\n- Task C \(beta\)/);
+    expect(fileContent).toMatch(/## alpha/);
+    expect(fileContent).toMatch(/## beta/);
   } finally {
     process.chdir(prev);
   }

--- a/test/manifest-filter.test.ts
+++ b/test/manifest-filter.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { latestFilesFor, ManifestEntry } from '../src/lib/utils/manifest';
 
 test('returns only files from requested version', () => {
@@ -10,5 +9,5 @@ test('returns only files from requested version', () => {
     { slug: 'demo', v: 'v2', timestamp: '20240104T000000', path: 'v2/latest.md' },
   ];
   const files = latestFilesFor(manifest, 'demo', 'v2');
-  assert.deepStrictEqual(files, ['v2/latest.md']);
+  expect(files).toEqual(['v2/latest.md']);
 });

--- a/test/no-export-get-link.test.ts
+++ b/test/no-export-get-link.test.ts
@@ -1,10 +1,9 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import Editor from '../src/components/Editor';
 
 test('editor has no direct GET export link', () => {
   const markup = renderToStaticMarkup(React.createElement(Editor));
-  assert.doesNotMatch(markup, /<a[^>]+href="\/api\/export"/);
+  expect(markup).not.toMatch(/<a[^>]+href="\/api\/export"/);
 });

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { mkdtemp, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
@@ -31,40 +30,19 @@ test('runSecretary generates a complete secretary.md', async () => {
     const content = await runSecretary(sampleSecretary);
     const filePath = path.join(dir, 'paper', 'secretary.md');
     const fileContent = await readFile(filePath, 'utf8');
-    assert.strictEqual(fileContent, content);
-    assert.match(fileContent, /Ready%: 100/);
-    assert.match(fileContent, /## Summary\nProject overview/);
-    assert.match(
-      fileContent,
-      /## Keywords\n- analysis\n- physics/
-    );
-    assert.match(
-      fileContent,
-      /## Tokens and Definitions\n- c: speed of light\n- m: mass/
-    );
-    assert.match(
-      fileContent,
-      /## Equations\n- E=mc\^2\n- a\^2 \+ b\^2 = c\^2/
-    );
-    assert.match(
-      fileContent,
-      /## Boundary Conditions\n- t=0\n- x->∞/
-    );
-    assert.match(fileContent, /## Post-Analysis\ndimensionless/);
-    assert.match(
-      fileContent,
-      /## Risks\n- oversimplification/
-    );
-    assert.match(
-      fileContent,
-      /## Predictions\n- growth/
-    );
-    assert.match(fileContent, /## Testability\nlab experiments/);
-    assert.match(
-      fileContent,
-      /## References\n- Einstein 1905\n- Pythagoras/
-    );
-    assert.match(fileContent, /## Issues\n\s*$/);
+    expect(fileContent).toBe(content);
+    expect(fileContent).toMatch(/Ready%: 100/);
+    expect(fileContent).toMatch(/## Summary\nProject overview/);
+    expect(fileContent).toMatch(/## Keywords\n- analysis\n- physics/);
+    expect(fileContent).toMatch(/## Tokens and Definitions\n- c: speed of light\n- m: mass/);
+    expect(fileContent).toMatch(/## Equations\n- E=mc\^2\n- a\^2 \+ b\^2 = c\^2/);
+    expect(fileContent).toMatch(/## Boundary Conditions\n- t=0\n- x->∞/);
+    expect(fileContent).toMatch(/## Post-Analysis\ndimensionless/);
+    expect(fileContent).toMatch(/## Risks\n- oversimplification/);
+    expect(fileContent).toMatch(/## Predictions\n- growth/);
+    expect(fileContent).toMatch(/## Testability\nlab experiments/);
+    expect(fileContent).toMatch(/## References\n- Einstein 1905\n- Pythagoras/);
+    expect(fileContent).toMatch(/## Issues\n\s*$/);
   } finally {
     process.chdir(prev);
   }
@@ -78,20 +56,11 @@ test('runResearchSecretary writes plan files with QN-21 table', async () => {
     const { name, content } = await runResearchSecretary('alpha', samplePlan);
     const filePath = path.join(dir, 'paper', `plan-${name}.md`);
     const fileContent = await readFile(filePath, 'utf8');
-    assert.strictEqual(fileContent, content);
-    assert.match(fileContent, /# Plan for alpha/);
-    assert.match(
-      fileContent,
-      /\| Item \| Priority \| QN-21 Criterion \|\n\|------\|----------\|-----------------\|/
-    );
-    assert.match(
-      fileContent,
-      /\| استكمال الاشتقاق \| P0 \| QN-21-1 \|/
-    );
-    assert.match(
-      fileContent,
-      /\| تحسين الواجهة \| P2 \| QN-21-8 \|/
-    );
+    expect(fileContent).toBe(content);
+    expect(fileContent).toMatch(/# Plan for alpha/);
+    expect(fileContent).toMatch(/\| Item \| Priority \| QN-21 Criterion \|\n\|------\|----------\|-----------------\|/);
+    expect(fileContent).toMatch(/\| استكمال الاشتقاق \| P0 \| QN-21-1 \|/);
+    expect(fileContent).toMatch(/\| تحسين الواجهة \| P2 \| QN-21-8 \|/);
   } finally {
     process.chdir(prev);
   }

--- a/test/snapshot-placeholder.test.ts
+++ b/test/snapshot-placeholder.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -37,10 +36,10 @@ test('placeholder files have stable fingerprints on regeneration', async () => {
   const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
   const biblio = manifest.filter((e: any) => e.path.endsWith('biblio.bib') && e.slug === 'demo' && e.v === 'v1');
   const figs = manifest.filter((e: any) => e.path.endsWith('figs/') && e.slug === 'demo' && e.v === 'v1');
-  assert.strictEqual(biblio.length, 2);
-  assert.strictEqual(figs.length, 2);
-  assert.strictEqual(new Set(biblio.map((e: any) => e.sha256)).size, 1);
-  assert.strictEqual(new Set(figs.map((e: any) => e.sha256)).size, 1);
+  expect(biblio.length).toBe(2);
+  expect(figs.length).toBe(2);
+  expect(new Set(biblio.map((e: any) => e.sha256)).size).toBe(1);
+  expect(new Set(figs.map((e: any) => e.sha256)).size).toBe(1);
 });
 
 test('saves role files with type role', async () => {
@@ -57,5 +56,6 @@ test('saves role files with type role', async () => {
   const manifestPath = path.join(dir, 'public', 'snapshots', 'manifest.json');
   const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
   const role = manifest.find((e: any) => e.path.endsWith('secretary.md'));
-  assert.ok(role && role.type === 'role');
+  expect(role).toBeTruthy();
+  expect((role as any).type).toBe('role');
 });

--- a/test/templates-endpoint.test.ts
+++ b/test/templates-endpoint.test.ts
@@ -1,5 +1,4 @@
-import test from 'node:test';
-import assert from 'node:assert';
+import { test, expect } from '@jest/globals';
 import { NextRequest } from 'next/server';
 import { GET } from '../src/app/api/templates/route';
 import { readFile } from 'node:fs/promises';
@@ -14,17 +13,17 @@ for (const name of files) {
   test(`serves ${name} with no-store header`, async () => {
     const req = new NextRequest(`${base}?name=${encodeURIComponent(name)}`);
     const res = await GET(req);
-    assert.strictEqual(res.status, 200);
-    assert.strictEqual(res.headers.get('Cache-Control'), 'no-store');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
     const body = await res.text();
-    assert.ok(body.length > 0);
+    expect(body.length).toBeGreaterThan(0);
     const expected = await readFile(path.join(templatesDir, name), 'utf8');
-    assert.strictEqual(body, expected);
+    expect(body).toBe(expected);
   });
 }
 
 test('missing template returns 404', async () => {
   const req = new NextRequest(`${base}?name=missing.md`);
   const res = await GET(req);
-  assert.strictEqual(res.status, 404);
+  expect(res.status).toBe(404);
 });


### PR DESCRIPTION
## Summary
- use Jest's `test` and `expect` APIs instead of Node's `test` and `assert`
- rewrite assertions across tests to rely on Jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0814f2d0c8321becc3cbb1265d779