### PR TITLE
Expand secretary gate checks

### DIFF
--- a/src/lib/workflow/gates.ts
+++ b/src/lib/workflow/gates.ts
@@ -4,7 +4,14 @@ export interface GateResult {
 }
 
 // Required fields for a complete secretary report
-const REQUIRED_FIELDS = ["summary", "equations", "references"];
+// These map directly to sections in templates/secretary.md
+const REQUIRED_FIELDS = [
+  "summary",
+  "keywords",
+  "equations",
+  "boundary",
+  "references",
+];
 
 // Check mandatory fields inside secretary report and return missing ones
 export function runGates(data: any): GateResult {

--- a/test/gates.test.ts
+++ b/test/gates.test.ts
@@ -2,14 +2,30 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { runGates } from '../src/lib/workflow';
 
-test('runGates detects missing fields', () => {
+test('runGates detects multiple missing fields', () => {
   const result = runGates({ secretary: { audit: { summary: 'A', equations: ['E=mc^2'] } } });
-  assert.strictEqual(result.ready_percent, 67);
-  assert.deepStrictEqual(result.missing, ['references']);
+  assert.strictEqual(result.ready_percent, 40);
+  assert.deepStrictEqual(result.missing, ['keywords', 'boundary', 'references']);
 });
 
-test('runGates passes when all fields present', () => {
-  const result = runGates({ secretary: { audit: { summary: 'A', equations: ['E=mc^2'], references: ['Ref'] } } });
+test('runGates passes when all required fields are present', () => {
+  const result = runGates({
+    secretary: {
+      audit: {
+        summary: 'A',
+        keywords: ['physics'],
+        equations: ['E=mc^2'],
+        boundary: ['t=0'],
+        references: ['Ref']
+      }
+    }
+  });
   assert.strictEqual(result.ready_percent, 100);
   assert.deepStrictEqual(result.missing, []);
+});
+
+test('runGates blocks evaluation when fields are missing', () => {
+  const gate = runGates({ secretary: { audit: { summary: 'Only summary' } } });
+  const shouldEvaluate = gate.missing.length === 0;
+  assert.strictEqual(shouldEvaluate, false);
 });


### PR DESCRIPTION
## Summary
- require secretary reports to include summary, keywords, equations, boundary conditions, and references
- provide detailed missing-field output and ready percentage
- expand gate tests to cover new required fields and prevent evaluation when incomplete

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a07a7ffa2883219321788ea4ba769d