### PR TITLE
Strip stateful flags from QN21 regex evaluation

### DIFF
--- a/src/lib/q21.ts
+++ b/src/lib/q21.ts
@@ -177,7 +177,12 @@ export interface QN21Result extends QN21Criterion {
  */
 export function evaluateQN21(text: string): QN21Result[] {
   return QN21_CRITERIA.map((c) => {
-    const score = c.patterns.some((p) => p.test(text)) ? c.weight : 0;
+    const score = c.patterns.some((p) => {
+      const k = new RegExp(p.source, p.flags.replace(/[gy]/g, ""));
+      return k.test(text);
+    })
+      ? c.weight
+      : 0;
     return { ...c, score, gap: c.weight - score };
   });
 }


### PR DESCRIPTION
## Summary
- ensure `evaluateQN21` recreates regexes without `g` or `y` flags before testing

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0871ed7048321b3cef7b9e7f414ee