### PR TITLE
chore: add test data setup script

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -4,3 +4,6 @@ This directory contains experimental sample data used in tests and documentation
 The `theory-demo` set mirrors the `QaadiDB` and `QaadiVault` structures with
 minimal registry, canonical and fingerprint files for the `demo` theory. These
 files exist only for examples and automated tests, never for production use.
+
+The test suite uses `scripts/setup-test-data.ts` to copy these examples into
+`QaadiDB` and `QaadiVault` before running.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "pretest": "ts-node scripts/setup-test-data.ts",
     "test": "jest",
     "migrate-registry": "ts-node scripts/migrate-registry.ts"
   },

--- a/scripts/setup-test-data.ts
+++ b/scripts/setup-test-data.ts
@@ -1,0 +1,18 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+async function main() {
+  const root = process.cwd();
+  const examples = path.join(root, 'docs', 'examples');
+  for (const dir of ['QaadiDB', 'QaadiVault']) {
+    const src = path.join(examples, dir);
+    const dest = path.join(root, dir);
+    await fs.rm(dest, { recursive: true, force: true });
+    await fs.cp(src, dest, { recursive: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add setup script to copy example data into QaadiDB and QaadiVault
- run setup script before tests
- document test data setup process

## Testing
- `npm test` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a08db088cc8321a525f348ba1053ce