### PR TITLE
Use Node test environment

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ const createJestConfig = nextJest({
 
 /** @type {import('jest').Config} */
 const config = {
-  testEnvironment: 'jsdom',
+  testEnvironment: 'node',
   transform: {
     '^.+\\.(ts|tsx)$': [
       'ts-jest',


### PR DESCRIPTION
## Summary
- use Node as the default Jest `testEnvironment`
- rely on per-test `@jest-environment jsdom` annotations for DOM-dependent tests

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: unknown env config "http-proxy" / process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a08daf4b1883219870f19e827e10b9