### PR TITLE
Implement partial scoring across criteria

### DIFF
--- a/src/lib/criteria.ts
+++ b/src/lib/criteria.ts
@@ -84,10 +84,11 @@ export function evaluateCriteria(
 ): CriterionResult[] {
   const lower = text.toLowerCase();
   return criteria.map((c) => {
-    const score =
-      c.enabled && c.keywords.some((k) => lower.includes(k.toLowerCase()))
-        ? c.weight
-        : 0;
+    if (!c.enabled) return { ...c, score: 0, gap: c.weight };
+
+    const matches = c.keywords.filter((k) => lower.includes(k.toLowerCase())).length;
+    const ratio = c.keywords.length === 0 ? 0 : matches / c.keywords.length;
+    const score = c.weight * ratio;
     return { ...c, score, gap: c.weight - score };
   });
 }

--- a/test/evaluateCriteriaPartial.test.ts
+++ b/test/evaluateCriteriaPartial.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert';
+import { evaluateCriteria, Criterion } from '../src/lib/criteria';
+
+test('evaluateCriteria returns partial scores and handles mismatches', () => {
+  const criteria: Criterion[] = [
+    {
+      id: 'P',
+      description: 'Partial coverage',
+      weight: 9,
+      keywords: ['alpha', 'beta', 'gamma'],
+      enabled: true,
+      version: 1,
+    },
+    {
+      id: 'N',
+      description: 'No match',
+      weight: 4,
+      keywords: ['delta'],
+      enabled: true,
+      version: 1,
+    },
+  ];
+
+  const text = 'alpha and gamma were mentioned';
+  const result = evaluateCriteria(text, criteria);
+
+  const partial = result.find((r) => r.id === 'P');
+  assert.ok(partial);
+  // Two of three keywords matched -> 2/3 of weight 9 = 6
+  assert.strictEqual(partial?.score, 6);
+  assert.strictEqual(partial?.gap, 3);
+
+  const none = result.find((r) => r.id === 'N');
+  assert.ok(none);
+  assert.strictEqual(none?.score, 0);
+  assert.strictEqual(none?.gap, 4);
+});

--- a/test/q21.test.ts
+++ b/test/q21.test.ts
@@ -11,18 +11,18 @@ test('evaluateQN21 returns scores and gaps based on patterns', () => {
 
   const equations = result.find((r) => r.code === 'equations');
   assert.ok(equations);
-  assert.strictEqual(equations?.score, 8);
-  assert.strictEqual(equations?.gap, 0);
+  assert.strictEqual(equations?.score, 8 * (2 / 3));
+  assert.strictEqual(equations?.gap, 8 - 8 * (2 / 3));
 
   const rigor = result.find((r) => r.code === 'rigor');
   assert.ok(rigor);
-  assert.strictEqual(rigor?.score, 6);
-  assert.strictEqual(rigor?.gap, 0);
+  assert.strictEqual(rigor?.score, 6 * (2 / 3));
+  assert.strictEqual(rigor?.gap, 6 - 6 * (2 / 3));
 
   const ethics = result.find((r) => r.code === 'ethics');
   assert.ok(ethics);
-  assert.strictEqual(ethics?.score, 8);
-  assert.strictEqual(ethics?.gap, 0);
+  assert.strictEqual(ethics?.score, 8 * (1 / 3));
+  assert.strictEqual(ethics?.gap, 8 - 8 * (1 / 3));
 
   const safety = result.find((r) => r.code === 'safety');
   assert.ok(safety);
@@ -37,15 +37,15 @@ test('evaluateQN21 detects uppercase and mixed-case indicators', () => {
 
   const equations = result.find((r) => r.code === 'equations');
   assert.ok(equations);
-  assert.strictEqual(equations?.score, 8);
+  assert.strictEqual(equations?.score, 8 * (2 / 3));
 
   const rigor = result.find((r) => r.code === 'rigor');
   assert.ok(rigor);
-  assert.strictEqual(rigor?.score, 6);
+  assert.strictEqual(rigor?.score, 6 * (2 / 3));
 
   const ethics = result.find((r) => r.code === 'ethics');
   assert.ok(ethics);
-  assert.strictEqual(ethics?.score, 8);
+  assert.strictEqual(ethics?.score, 8 * (1 / 3));
 });
 
 test('evaluateQN21 handles partial criteria in text', () => {
@@ -55,7 +55,7 @@ test('evaluateQN21 handles partial criteria in text', () => {
 
   const calibration = result.find((r) => r.code === 'calibration');
   assert.ok(calibration);
-  assert.strictEqual(calibration?.score, 3);
+  assert.strictEqual(calibration?.score, 3 * (1 / 3));
 
   const reproducibility = result.find((r) => r.code === 'reproducibility');
   assert.ok(reproducibility);
@@ -63,7 +63,7 @@ test('evaluateQN21 handles partial criteria in text', () => {
 
   const engagement = result.find((r) => r.code === 'engagement');
   assert.ok(engagement);
-  assert.strictEqual(engagement?.score, 5);
+  assert.strictEqual(engagement?.score, 5 * (2 / 3));
 });
 
 test('summarizeQN21 computes totals, max, percentage, and classification', () => {


### PR DESCRIPTION
## Summary
- allow partial scoring for custom criteria based on proportion of keywords matched
- compute QN21 scores proportionally to matched patterns
- add tests for partial coverage and non-matching cases

## Testing
- `npm test` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a094bcfbdc8321972550058876e0d9