### PR TITLE
Refactor secretary required fields and update template

### DIFF
--- a/src/lib/workers/secretary.ts
+++ b/src/lib/workers/secretary.ts
@@ -7,13 +7,11 @@ export interface SecretaryData {
   summary: string;
   keywords: string[];
   tokens: string[];
-  equations: string[];
   boundary: string[];
   post_analysis: string;
   risks: string[];
   predictions: string[];
   testability: string;
-  references: string[];
 }
 
 /**
@@ -25,13 +23,11 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
   let summary: string;
   let keywords: string[];
   let tokens: string[];
-  let equations: string[];
   let boundary: string[];
   let post_analysis: string;
   let risks: string[];
   let predictions: string[];
   let testability: string;
-  let references: string[];
 
   if (!data) {
     const rl = createInterface({ input, output });
@@ -51,14 +47,9 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
         .split(",")
         .map((t) => t.trim())
         .filter(Boolean);
-      const eqInput = await rl.question("Equations (comma separated): ");
-      equations = eqInput
-        .split(",")
-        .map((e) => e.trim())
-        .filter(Boolean);
-      const boundInput = await rl.question(
-        "Boundary conditions (comma separated): "
-      );
+        const boundInput = await rl.question(
+          "Boundary conditions (comma separated): "
+        );
       boundary = boundInput
         .split(",")
         .map((b) => b.trim())
@@ -74,42 +65,32 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
         .split(",")
         .map((p) => p.trim())
         .filter(Boolean);
-      testability = await rl.question("Testability: ");
-      const refInput = await rl.question("References (comma separated): ");
-      references = refInput
-        .split(",")
-        .map((r) => r.trim())
-        .filter(Boolean);
-    } finally {
-      rl.close();
+        testability = await rl.question("Testability: ");
+      } finally {
+        rl.close();
+      }
+    } else {
+      ({
+        summary = "",
+        keywords = [],
+        tokens = [],
+        boundary = [],
+        post_analysis = "",
+        risks = [],
+        predictions = [],
+        testability = "",
+      } = data);
     }
-  } else {
-    ({
-      summary = "",
-      keywords = [],
-      tokens = [],
-      equations = [],
-      boundary = [],
-      post_analysis = "",
-      risks = [],
-      predictions = [],
-      testability = "",
-      references = [],
-    } = data);
-  }
 
-  const fields = {
-    summary,
-    keywords,
-    tokens,
-    equations,
-    boundary,
-    post_analysis,
-    risks,
-    predictions,
-    testability,
-    references,
-  };
+    const fields = {
+      keywords,
+      tokens,
+      boundary,
+      post_analysis,
+      risks,
+      predictions,
+      testability,
+    };
   const missing = Object.entries(fields)
     .filter(([, v]) =>
       v === undefined ||
@@ -138,9 +119,6 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
     "## Tokens and Definitions",
     ...tokens.map((t) => `- ${t}`),
     "",
-    "## Equations",
-    ...equations.map((e) => `- ${e}`),
-    "",
     "## Boundary Conditions",
     ...boundary.map((b) => `- ${b}`),
     "",
@@ -155,9 +133,6 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
     "",
     "## Testability",
     testability,
-    "",
-    "## References",
-    ...references.map((r) => `- ${r}`),
     "",
     "## Issues",
     ...missing.map((m) => `- type: missing_field\n  note: ${m}`),

--- a/src/lib/workflow/gates.ts
+++ b/src/lib/workflow/gates.ts
@@ -6,11 +6,13 @@ export interface GateResult {
 // Required fields for a complete secretary report
 // These map directly to sections in templates/secretary.md
 const REQUIRED_FIELDS = [
-  "summary",
   "keywords",
-  "equations",
+  "tokens",
   "boundary",
-  "references",
+  "post_analysis",
+  "risks",
+  "predictions",
+  "testability",
 ];
 
 // Check mandatory fields inside secretary report and return missing ones

--- a/templates/secretary.md
+++ b/templates/secretary.md
@@ -1,4 +1,4 @@
-<!-- mandatory fields: ready_percent, issues[].type, issues[].note -->
+<!-- mandatory fields: ready_percent, issues[].type, issues[].note, keywords, tokens, boundary, post_analysis, risks, predictions, testability -->
 
 Ready%: 100
 
@@ -17,11 +17,6 @@ Ready%: 100
 | \(m\) | الكتلة |
 | \(E\) | الطاقة |
 
-## معادلات
-\[
-E = mc^2
-\]
-
 ## شروط حدية
 - \(t = 0\) : الحالة الابتدائية للنظام.
 - \(x \to \infty\) : تبديد الطاقة يقترب من الصفر.
@@ -39,8 +34,6 @@ E = mc^2
 ## قابلية الاختبار
 توضح الشروط أو التجارب اللازمة للتحقق من صحة الفرضيات.
 
-## المراجع
-- [1] اسم المؤلف، "عنوان المرجع"، سنة النشر.
 
 ## Issues
 - type: none

--- a/test/gates.test.ts
+++ b/test/gates.test.ts
@@ -3,29 +3,39 @@ import assert from 'node:assert';
 import { runGates } from '../src/lib/workflow';
 
 test('runGates detects multiple missing fields', () => {
-  const result = runGates({ secretary: { audit: { summary: 'A', equations: ['E=mc^2'] } } });
-  assert.strictEqual(result.ready_percent, 40);
-  assert.deepStrictEqual(result.missing, ['keywords', 'boundary', 'references']);
+  const result = runGates({
+    secretary: { audit: { keywords: ['physics'], tokens: ['c: light'] } }
+  });
+  assert.strictEqual(result.ready_percent, 29);
+  assert.deepStrictEqual(result.missing, [
+    'boundary',
+    'post_analysis',
+    'risks',
+    'predictions',
+    'testability',
+  ]);
 });
 
 test('runGates passes when all required fields are present', () => {
   const result = runGates({
     secretary: {
       audit: {
-        summary: 'A',
         keywords: ['physics'],
-        equations: ['E=mc^2'],
+        tokens: ['c: light'],
         boundary: ['t=0'],
-        references: ['Ref']
-      }
-    }
+        post_analysis: 'dimensionless',
+        risks: ['oversimplification'],
+        predictions: ['growth'],
+        testability: 'lab',
+      },
+    },
   });
   assert.strictEqual(result.ready_percent, 100);
   assert.deepStrictEqual(result.missing, []);
 });
 
 test('runGates blocks evaluation when fields are missing', () => {
-  const gate = runGates({ secretary: { audit: { summary: 'Only summary' } } });
+  const gate = runGates({ secretary: { audit: { keywords: [] } } });
   const shouldEvaluate = gate.missing.length === 0;
   assert.strictEqual(shouldEvaluate, false);
 });

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -9,13 +9,11 @@ const sampleSecretary = {
   summary: 'Project overview',
   keywords: ['analysis', 'physics'],
   tokens: ['c: speed of light', 'm: mass'],
-  equations: ['E=mc^2', 'a^2 + b^2 = c^2'],
   boundary: ['t=0', 'x->∞'],
   post_analysis: 'dimensionless',
   risks: ['oversimplification'],
   predictions: ['growth'],
   testability: 'lab experiments',
-  references: ['Einstein 1905', 'Pythagoras'],
 };
 
 const samplePlan = [
@@ -44,10 +42,6 @@ test('runSecretary generates a complete secretary.md', async () => {
     );
     assert.match(
       fileContent,
-      /## Equations\n- E=mc\^2\n- a\^2 \+ b\^2 = c\^2/
-    );
-    assert.match(
-      fileContent,
       /## Boundary Conditions\n- t=0\n- x->∞/
     );
     assert.match(fileContent, /## Post-Analysis\ndimensionless/);
@@ -60,10 +54,6 @@ test('runSecretary generates a complete secretary.md', async () => {
       /## Predictions\n- growth/
     );
     assert.match(fileContent, /## Testability\nlab experiments/);
-    assert.match(
-      fileContent,
-      /## References\n- Einstein 1905\n- Pythagoras/
-    );
     assert.match(fileContent, /## Issues\n\s*$/);
   } finally {
     process.chdir(prev);


### PR DESCRIPTION
## Summary
- enforce new required secretary fields (keywords, tokens, boundary, post-analysis, risks, predictions, testability)
- streamline secretary worker and template to focus on essential fields
- update gate logic and tests for new field set

## Testing
- `npm test` *(fails: sh: 1: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a094ba53088321996df8fe0a29fe49