### PR TITLE
feat: add translation pipeline and direction handling

### DIFF
--- a/src/components/LangDirProvider.tsx
+++ b/src/components/LangDirProvider.tsx
@@ -11,8 +11,16 @@ export default function LangDirProvider() {
   useEffect(() => {
     try {
       const l = localStorage.getItem("lang");
+      const d = localStorage.getItem("dir") as "ltr" | "rtl" | null;
       if (l) setLang(l);
+      if (d) setDir(d);
     } catch {}
+
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === "lang" && e.newValue) setLang(e.newValue);
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
   }, []);
 
   useEffect(() => {

--- a/src/lib/buildPrompt.ts
+++ b/src/lib/buildPrompt.ts
@@ -51,10 +51,12 @@ export function buildPrompt(
   const frozen = freezeText(userText);
   const gloss =
     glossary && Object.keys(glossary).length
-      ? "\nGlossary:\n" +
-        Object.entries(glossary)
-          .map(([k, v]) => `${k} = ${v}`)
-          .join("\n")
+      ? (() => {
+          const entries = Object.entries(glossary)
+            .map(([k, v]) => `${k} = ${v}`)
+            .join("\n");
+          return "\nGlossary:\n" + freezeText(entries).text;
+        })()
       : "";
 
   if (target === "wide") {


### PR DESCRIPTION
## Summary
- return per-language direction info from translation endpoint
- freeze glossary text to protect equations and symbols
- persist and auto-update language direction in LangDirProvider

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*
- `npm test` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a094b478dc8321999ab8a62c7e7b0d