### PR TITLE
fix: reset regex lastIndex for QN21 scoring

### DIFF
--- a/src/lib/q21.ts
+++ b/src/lib/q21.ts
@@ -174,12 +174,12 @@ export interface QN21Result extends QN21Criterion {
  * The evaluation is pattern based: if any regular expression for a criterion
  * matches within the provided text the full weight is awarded. Otherwise the
  * score is zero. The `gap` field expresses the missing weight.
- */
+  */
 export function evaluateQN21(text: string): QN21Result[] {
   return QN21_CRITERIA.map((c) => {
     const score = c.patterns.some((p) => {
-      const k = new RegExp(p.source, p.flags.replace(/[gy]/g, ""));
-      return k.test(text);
+      p.lastIndex = 0;
+      return p.test(text);
     })
       ? c.weight
       : 0;

--- a/test/q21.test.ts
+++ b/test/q21.test.ts
@@ -102,3 +102,27 @@ test('summarizeQN21 computes totals, max, percentage, and classification', () =>
   assert.strictEqual(summary.classification, 'needs_improvement');
 });
 
+test('evaluateQN21 handles sticky regex patterns consistently', () => {
+  const stickyCriterion = {
+    code: 'sticky',
+    type: 'internal',
+    weight: 1,
+    description: '',
+    patterns: [/ma/y],
+  } as const;
+  QN21_CRITERIA.push(stickyCriterion as any);
+  try {
+    const text = 'ma';
+    const run = () => {
+      const result = evaluateQN21(text);
+      const sticky = result.find((r) => r.code === 'sticky');
+      assert.ok(sticky);
+      assert.strictEqual(sticky?.score, 1);
+    };
+    run();
+    run();
+  } finally {
+    QN21_CRITERIA.pop();
+  }
+});
+


### PR DESCRIPTION
## Summary
- reset each pattern's `lastIndex` before testing to support global/sticky regexes
- add regression test for sticky regex patterns

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a093f23e208321ac88dedf01aac9de