### PR TITLE
Improve QN21 score gap handling and add tests

### DIFF
--- a/src/lib/q21.ts
+++ b/src/lib/q21.ts
@@ -85,7 +85,11 @@ export function evaluateQN21(text: string): QN21Result[] {
     }, 0);
     const ratio = c.patterns.length === 0 ? 0 : matches / c.patterns.length;
     const score = c.weight * ratio;
-    return { ...c, score, gap: c.weight - score };
+    const gap = Math.max(0, c.weight - score);
+    console.log(
+      `evaluateQN21: ${c.code} matches=${matches}, score=${score}, gap=${gap}`
+    );
+    return { ...c, score, gap };
   });
 }
 

--- a/src/lib/workers/judge.ts
+++ b/src/lib/workers/judge.ts
@@ -29,6 +29,8 @@ export async function runJudge(text?: string) {
   const qn21Results = evaluateQN21(content);
   const custom = await loadCriteria();
   const customResults = evaluateCriteria(content, custom);
+  console.log("runJudge: qn21Results", qn21Results);
+  console.log("runJudge: customResults", customResults);
 
   const combined: ChartCriterion[] = [];
   qn21Results.forEach((c, i) => {
@@ -36,7 +38,7 @@ export async function runJudge(text?: string) {
       id: i + 1,
       name: c.description,
       score: c.score,
-      gap: c.gap,
+      gap: Math.max(0, c.weight - c.score),
       type: c.type,
       covered: c.score === c.weight,
     });
@@ -46,10 +48,12 @@ export async function runJudge(text?: string) {
       id: qn21Results.length + i + 1,
       name: c.description,
       score: c.score,
-      gap: c.gap,
+      gap: Math.max(0, c.weight - c.score),
       covered: c.score === c.weight,
     });
   });
+
+  console.log("runJudge: combined criteria", combined);
 
   const total = [...qn21Results, ...customResults].reduce((s, c) => s + c.score, 0);
   const max = [...qn21Results, ...customResults].reduce((s, c) => s + c.weight, 0);
@@ -60,6 +64,11 @@ export async function runJudge(text?: string) {
   const gaps = combined
     .filter((c) => c.gap > 0)
     .map((c) => ({ id: c.id, name: c.name, gap: c.gap }));
+
+  console.log(
+    `runJudge: total=${total}, max=${max}, percentage=${percentage}, classification=${classification}`
+  );
+  console.log("runJudge: gaps", gaps);
 
   const result = {
     verdict: "approved",

--- a/test/judge.test.ts
+++ b/test/judge.test.ts
@@ -46,3 +46,10 @@ test('runJudge computes scores, gaps, and classification', async () => {
   }
 });
 
+test('runJudge never returns negative gaps', async () => {
+  const result = await runJudge('Equation and equations ensure rigor');
+  result.criteria.forEach((c: any) => {
+    assert.ok(c.gap >= 0);
+  });
+});
+

--- a/test/q21.test.ts
+++ b/test/q21.test.ts
@@ -64,6 +64,15 @@ test('evaluateQN21 handles partial criteria in text', () => {
   assert.strictEqual(diagrams?.score, 2 * (1 / 3));
 });
 
+test('evaluateQN21 gives full score when all indicators match', () => {
+  const text = 'Equation and equations illustrate fundamental EQUATIONs.';
+  const result = evaluateQN21(text);
+  const equations = result.find((r) => r.code === 'equations');
+  assert.ok(equations);
+  assert.strictEqual(equations?.score, 5);
+  assert.strictEqual(equations?.gap, 0);
+});
+
 test('summarizeQN21 computes totals, max, percentage, and classification', () => {
   const criterionA = {
     code: 'c1',


### PR DESCRIPTION
## Summary
- log evaluation details while computing QN21 scores
- ensure runJudge uses non-negative gaps and logs intermediate data
- add tests for full-score QN21 matches and non-negative judge gaps

## Testing
- `npm install --save-dev jest-environment-jsdom` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d2af54648321a09797987ef9b7aa