### PR TITLE
fix: ensure runLead outputs best items without extra blank line

### DIFF
--- a/src/lib/workers/lead.ts
+++ b/src/lib/workers/lead.ts
@@ -38,12 +38,13 @@ export async function runLead(cards: string[], root = process.cwd()) {
     ([item, sources]) => `- ${item} (${Array.from(sources).join(", ")})`
   );
 
-  const header = [
+  const headerLines = [
     "# Comparison",
     "",
     "## Best Items",
-    bestLines.length ? bestLines.join("\n") : "- None",
-  ].join("\n");
+    ...(bestLines.length ? bestLines : ["- None"]),
+  ];
+  const header = headerLines.join("\n");
   const content = [header, ...sections].join("\n\n");
 
   const filePath = path.join(dir, "comparison.md");


### PR DESCRIPTION
## Summary
- build lead comparison header line-by-line to avoid extra blank line before best items list

## Testing
- `npm test` *(fails: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a0d5568d848321aec1c390c43fba42