### PR TITLE
Expand gates and classify custom criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Qaadi Live
+
+This repository hosts the core modules for the **Qaadi** workflow: secretary, judge, consultant and related utilities.
+
+## Quick Start
+
+```bash
+npm install
+npm test
+```
+
+The system evaluates scientific drafts using the QN-21 criteria and optional custom criteria. The secretary gate checks ensure required fields (summary, keywords, tokens, boundary, post-analysis, risks, predictions and testability) are present before running the judge.
+

--- a/src/app/api/criteria/route.ts
+++ b/src/app/api/criteria/route.ts
@@ -22,19 +22,20 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
-    const { id, description, weight, keywords, enabled = true } = await req.json();
+    const { id, description, weight, keywords, category, enabled = true } = await req.json();
     if (
       !id ||
       typeof description !== "string" ||
       typeof weight !== "number" ||
-      !Array.isArray(keywords)
+      !Array.isArray(keywords) ||
+      (category !== "internal" && category !== "external" && category !== "advisory")
     ) {
       return new Response(JSON.stringify({ error: "invalid_params" }), {
         status: 400,
         headers,
       });
     }
-    const criteria = await addCriterion({ id, description, weight, keywords, enabled });
+    const criteria = await addCriterion({ id, description, weight, keywords, category, enabled });
     const added = criteria.find((c) => c.id === id);
     return new Response(JSON.stringify(added), { status: 201, headers });
   } catch {

--- a/src/components/ScoreCharts.tsx
+++ b/src/components/ScoreCharts.tsx
@@ -5,7 +5,7 @@ interface Criterion {
   id: number;
   name: string;
   score: number;
-  type?: "internal" | "external";
+  type?: "internal" | "external" | "advisory";
   covered?: boolean;
 }
 
@@ -39,7 +39,13 @@ export default function ScoreCharts({ criteria }: Props) {
       const labels = criteria.map(c => c.name);
       const scores = criteria.map(c => c.score);
       const colors = criteria.map(c =>
-        c.covered ? "#16a34a" : c.type === "external" ? "#1d4ed8" : "#dc2626"
+        c.covered
+          ? "#16a34a"
+          : c.type === "external"
+          ? "#1d4ed8"
+          : c.type === "advisory"
+          ? "#9333ea"
+          : "#dc2626"
       );
 
       if (barRef.current) {
@@ -95,6 +101,7 @@ export default function ScoreCharts({ criteria }: Props) {
       <div className="legend">
         <span><span className="box internal" /> داخلي</span>
         <span><span className="box external" /> خارجي</span>
+        <span><span className="box advisory" /> استشاري</span>
         <span><span className="box covered" /> مكتمل</span>
       </div>
       <div className="chart-wrapper"><canvas ref={barRef} /></div>
@@ -104,6 +111,7 @@ export default function ScoreCharts({ criteria }: Props) {
         .box { display:inline-block; width:12px; height:12px; margin-right:4px; }
         .internal { background:#dc2626; }
         .external { background:#1d4ed8; }
+        .advisory { background:#9333ea; }
         .covered { background:#16a34a; }
         .chart-wrapper { margin-bottom:16px; }
       `}</style>

--- a/src/lib/criteria.ts
+++ b/src/lib/criteria.ts
@@ -12,6 +12,8 @@ export interface Criterion {
   keywords: string[];
   /** Whether the criterion is active */
   enabled: boolean;
+  /** Classification for the criterion */
+  category: "internal" | "external" | "advisory";
   /** Version number for this criterion */
   version: number;
 }

--- a/src/lib/q21.ts
+++ b/src/lib/q21.ts
@@ -51,6 +51,21 @@ const PATTERN_MAP: Record<string, RegExp[]> = {
   reproducibility: [/\breproducibility\b/i, /\breproducible\b/i, /\breproduce\b/i],
   predictions: [/\bprediction\b/i, /\bpredictions\b/i, /\bpredict\b/i],
   diagrams: [/\bdiagram\b/i, /\bdiagrams\b/i, /\btable\b/i],
+  dimensional: [/\bdimensional\b/i, /\bunits?\b/i, /\bsi\b/i],
+  symmetry: [/\bsymmetry\b/i, /\bnoether\b/i, /\bsymmetric\b/i],
+  conservation: [/\bconservation\b/i, /\bconserve\b/i, /\bpreservation\b/i],
+  boundary: [/\bboundary\b/i, /\bboundaries\b/i, /initial\s+conditions?/i],
+  consistency: [/\bconsistency\b/i, /\bconsistent\b/i, /\bcoherence\b/i],
+  scope: [/\bscope\b/i, /\brange\b/i, /\bapplicability\b/i],
+  novelty: [/\bnovel\b/i, /\binnovation\b/i, /\boriginal\b/i],
+  falsifiability: [/\bfalsifiabl\w*/i, /\bfalsify\b/i, /\brefut\w*/i],
+  methodology: [/\bmethodolog\w*/i, /\bprotocol\b/i, /\bprocedure\b/i],
+  definitions: [/\bdefinition\b/i, /\bdefine\b/i, /\bdefin\w*/i],
+  terminology: [/\bterminology\b/i, /\bterms?\b/i, /\bvocabulary\b/i],
+  clarity: [/\bclarity\b/i, /\bclear\b/i, /\btransparent\b/i],
+  limitations: [/\blimitations?\b/i, /\brisk\b/i, /\bconstraint\b/i],
+  expAlignment: [/\bexperiment\w*/i, /\bdata\b/i, /\bmeasurement\b/i],
+  references: [/\breference\b/i, /\bcitation\b/i, /\bbibliograph\w*/i],
 };
 
 export const QN21_CRITERIA: QN21Criterion[] = DOCUMENTED_QN21_CRITERIA.map((c) => ({

--- a/src/lib/workers/judge.ts
+++ b/src/lib/workers/judge.ts
@@ -8,7 +8,7 @@ interface ChartCriterion {
   name: string;
   score: number;
   gap: number;
-  type?: "internal" | "external";
+  type?: "internal" | "external" | "advisory";
   covered?: boolean;
 }
 
@@ -49,6 +49,7 @@ export async function runJudge(text?: string) {
       name: c.description,
       score: c.score,
       gap: Math.max(0, c.weight - c.score),
+      type: c.category,
       covered: c.score === c.weight,
     });
   });

--- a/src/lib/workers/secretary.ts
+++ b/src/lib/workers/secretary.ts
@@ -83,6 +83,7 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
     }
 
     const fields = {
+      summary,
       keywords,
       tokens,
       boundary,

--- a/src/lib/workflow/gates.ts
+++ b/src/lib/workflow/gates.ts
@@ -6,6 +6,7 @@ export interface GateResult {
 // Required fields for a complete secretary report
 // These map directly to sections in templates/secretary.md
 const REQUIRED_FIELDS = [
+  "summary",
   "keywords",
   "tokens",
   "boundary",

--- a/templates/secretary.md
+++ b/templates/secretary.md
@@ -1,4 +1,4 @@
-<!-- mandatory fields: ready_percent, issues[].type, issues[].note, keywords, tokens, boundary, post_analysis, risks, predictions, testability -->
+<!-- mandatory fields: ready_percent, issues[].type, issues[].note, summary, keywords, tokens, boundary, post_analysis, risks, predictions, testability -->
 
 Ready%: 100
 

--- a/test/customCriteria.test.ts
+++ b/test/customCriteria.test.ts
@@ -15,6 +15,7 @@ test('CRUD and evaluation for custom criteria', async () => {
     description: 'Test criterion',
     weight: 2,
     keywords: ['foo'],
+    category: 'advisory',
     enabled: true
   });
   let criteria = await loadCriteria();
@@ -22,11 +23,13 @@ test('CRUD and evaluation for custom criteria', async () => {
   let crit = result.find((c) => c.id === 'TST');
   assert.ok(crit);
   assert.strictEqual(crit?.score, 2);
+  assert.strictEqual(crit?.category, 'advisory');
 
   const judge = await runJudge('foo equation');
   const jCrit = judge.criteria.find((c: any) => c.name === 'Test criterion');
   assert.ok(jCrit);
   assert.strictEqual(jCrit.score, 2);
+  assert.strictEqual(jCrit.type, 'advisory');
   const qn = judge.criteria.find((c: any) => c.name === 'Equation accuracy');
   assert.ok(qn && qn.score > 0);
 

--- a/test/evaluateCriteriaPartial.test.ts
+++ b/test/evaluateCriteriaPartial.test.ts
@@ -9,6 +9,7 @@ test('evaluateCriteria returns partial scores and handles mismatches', () => {
       weight: 9,
       keywords: ['alpha', 'beta', 'gamma'],
       enabled: true,
+      category: 'advisory',
       version: 1,
     },
     {
@@ -17,6 +18,7 @@ test('evaluateCriteria returns partial scores and handles mismatches', () => {
       weight: 4,
       keywords: ['delta'],
       enabled: true,
+      category: 'advisory',
       version: 1,
     },
   ];

--- a/test/gates.test.ts
+++ b/test/gates.test.ts
@@ -6,8 +6,9 @@ test('runGates detects multiple missing fields', () => {
   const result = runGates({
     secretary: { audit: { keywords: ['physics'], tokens: ['c: light'] } }
   });
-  assert.strictEqual(result.ready_percent, 29);
+  assert.strictEqual(result.ready_percent, 25);
   assert.deepStrictEqual(result.missing, [
+    'summary',
     'boundary',
     'post_analysis',
     'risks',
@@ -20,6 +21,7 @@ test('runGates passes when all required fields are present', () => {
   const result = runGates({
     secretary: {
       audit: {
+        summary: 'Overview',
         keywords: ['physics'],
         tokens: ['c: light'],
         boundary: ['t=0'],


### PR DESCRIPTION
## Summary
- Require secretary summaries for gate checks and update templates
- Add category field for custom criteria with advisory chart color
- Broaden QN-21 keyword patterns and document usage in README

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden for @types/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dbba8de483218a912e60fc706259