### PR TITLE
feat: add typed secretary report to runGates

### DIFF
--- a/src/lib/workflow/gates.ts
+++ b/src/lib/workflow/gates.ts
@@ -3,6 +3,17 @@ export interface GateResult {
   missing: string[];
 }
 
+export interface SecretaryReport {
+  summary?: string;
+  keywords?: string[];
+  tokens?: string[];
+  boundary?: string[];
+  post_analysis?: string;
+  risks?: string[];
+  predictions?: string[];
+  testability?: string;
+}
+
 // Required fields for a complete secretary report
 // These map directly to sections in templates/secretary.md
 const REQUIRED_FIELDS = [
@@ -17,8 +28,8 @@ const REQUIRED_FIELDS = [
 ];
 
 // Check mandatory fields inside secretary report and return missing ones
-export function runGates(data: any): GateResult {
-  const report = data?.secretary?.audit ?? data;
+export function runGates(data: { secretary?: { audit?: SecretaryReport } }): GateResult {
+  const report = data.secretary?.audit;
   const missing: string[] = [];
 
   if (!report || typeof report !== "object") {
@@ -26,7 +37,7 @@ export function runGates(data: any): GateResult {
   }
 
   for (const field of REQUIRED_FIELDS) {
-    const value = (report as any)[field];
+    const value = report[field as keyof SecretaryReport];
     const isMissing =
       value === undefined ||
       value === null ||

--- a/src/lib/workflow/index.ts
+++ b/src/lib/workflow/index.ts
@@ -1,2 +1,2 @@
 export { runGates } from "./gates";
-export type { GateResult } from "./gates";
+export type { GateResult, SecretaryReport } from "./gates";

--- a/test/gates.test.ts
+++ b/test/gates.test.ts
@@ -1,11 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { runGates } from '../src/lib/workflow';
+import { runGates, type SecretaryReport } from '../src/lib/workflow';
 
 test('runGates detects multiple missing fields', () => {
-  const result = runGates({
-    secretary: { audit: { keywords: ['physics'], tokens: ['c: light'] } }
-  });
+  const audit: SecretaryReport = { keywords: ['physics'], tokens: ['c: light'] };
+  const result = runGates({ secretary: { audit } });
   assert.strictEqual(result.ready_percent, 25);
   assert.deepStrictEqual(result.missing, [
     'summary',
@@ -18,26 +17,24 @@ test('runGates detects multiple missing fields', () => {
 });
 
 test('runGates passes when all required fields are present', () => {
-  const result = runGates({
-    secretary: {
-      audit: {
-        summary: 'Overview',
-        keywords: ['physics'],
-        tokens: ['c: light'],
-        boundary: ['t=0'],
-        post_analysis: 'dimensionless',
-        risks: ['oversimplification'],
-        predictions: ['growth'],
-        testability: 'lab',
-      },
-    },
-  });
+  const audit: SecretaryReport = {
+    summary: 'Overview',
+    keywords: ['physics'],
+    tokens: ['c: light'],
+    boundary: ['t=0'],
+    post_analysis: 'dimensionless',
+    risks: ['oversimplification'],
+    predictions: ['growth'],
+    testability: 'lab',
+  };
+  const result = runGates({ secretary: { audit } });
   assert.strictEqual(result.ready_percent, 100);
   assert.deepStrictEqual(result.missing, []);
 });
 
 test('runGates blocks evaluation when fields are missing', () => {
-  const gate = runGates({ secretary: { audit: { keywords: [] } } });
+  const audit: SecretaryReport = { keywords: [] };
+  const gate = runGates({ secretary: { audit } });
   const shouldEvaluate = gate.missing.length === 0;
   assert.strictEqual(shouldEvaluate, false);
 });


### PR DESCRIPTION
## Summary
- define `SecretaryReport` interface for secretary audit data
- type `runGates` to accept objects with optional secretary audit
- refactor gate tests to use typed reports

## Testing
- `npm test` *(fails: jest not found)*
- `node --loader ts-node/esm --test test/gates.test.ts` *(fails: Cannot find module 'ts-node/esm')*

------
https://chatgpt.com/codex/tasks/task_e_68a0e2c065108321b9cda1f840371b88