### PR TITLE
Use glob test match pattern and document in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,11 @@ npm install
 npm test
 ```
 
+## Testing
+
+Jest discovers test files using the pattern `**/test/**/*.test.ts`. Place your
+tests in a `test` directory and use the `.test.ts` suffix so they are executed
+when running `npm test`.
+
 The system evaluates scientific drafts using the QN-21 criteria and optional custom criteria. The secretary gate checks ensure required fields (summary, keywords, tokens, boundary, post-analysis, risks, predictions and testability) are present before running the judge.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,9 +19,8 @@ const config = {
     ],
   },
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  testMatch: [
-    '**/test/(q21|judge|customCriteria|evaluateCriteriaPartial|health).test.ts',
-  ],
+  // Match all test files within any `test` directory
+  testMatch: ['**/test/**/*.test.ts'],
 };
 
 export default createJestConfig(config);


### PR DESCRIPTION
## Summary
- simplify Jest configuration with `**/test/**/*.test.ts` glob
- document test file pattern in README

## Testing
- `npm test` *(fails: jest: not found, dependencies could not be installed)*


------
https://chatgpt.com/codex/tasks/task_e_68a0e2bd587483218cc8bf638dd4c2c4