### PR TITLE
feat: add debug flag to judge logging

### DIFF
--- a/src/lib/workers/judge.ts
+++ b/src/lib/workers/judge.ts
@@ -29,8 +29,9 @@ export async function runJudge(text?: string) {
   const qn21Results = evaluateQN21(content);
   const custom = await loadCriteria();
   const customResults = evaluateCriteria(content, custom);
-  console.log("runJudge: qn21Results", qn21Results);
-  console.log("runJudge: customResults", customResults);
+  const debug = process.env.DEBUG_JUDGE === "true";
+  if (debug) console.log("runJudge: qn21Results", qn21Results);
+  if (debug) console.log("runJudge: customResults", customResults);
 
   const combined: ChartCriterion[] = [];
   qn21Results.forEach((c, i) => {
@@ -54,7 +55,7 @@ export async function runJudge(text?: string) {
     });
   });
 
-  console.log("runJudge: combined criteria", combined);
+  if (debug) console.log("runJudge: combined criteria", combined);
 
   const total = [...qn21Results, ...customResults].reduce((s, c) => s + c.score, 0);
   const max = [...qn21Results, ...customResults].reduce((s, c) => s + c.weight, 0);
@@ -66,10 +67,11 @@ export async function runJudge(text?: string) {
     .filter((c) => c.gap > 0)
     .map((c) => ({ id: c.id, name: c.name, gap: c.gap }));
 
-  console.log(
-    `runJudge: total=${total}, max=${max}, percentage=${percentage}, classification=${classification}`
-  );
-  console.log("runJudge: gaps", gaps);
+  if (debug)
+    console.log(
+      `runJudge: total=${total}, max=${max}, percentage=${percentage}, classification=${classification}`
+    );
+  if (debug) console.log("runJudge: gaps", gaps);
 
   const result = {
     verdict: "approved",

--- a/test/judge.test.ts
+++ b/test/judge.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { mkdtemp, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
+import { jest } from '@jest/globals';
 
 import { runJudge } from '../src/lib/workers/judge';
 import { evaluateQN21 } from '../src/lib/q21';
@@ -51,5 +52,32 @@ test('runJudge never returns negative gaps', async () => {
   result.criteria.forEach((c: any) => {
     assert.ok(c.gap >= 0);
   });
+});
+
+test('runJudge logs only when DEBUG_JUDGE is true', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  try {
+    delete process.env.DEBUG_JUDGE;
+    await runJudge('Equation and equations ensure rigor');
+    let judgeLogs = spy.mock.calls.filter(
+      ([msg]) => typeof msg === 'string' && msg.startsWith('runJudge:')
+    );
+    assert.strictEqual(judgeLogs.length, 0);
+
+    spy.mockClear();
+    process.env.DEBUG_JUDGE = 'true';
+    await runJudge('Equation and equations ensure rigor');
+    judgeLogs = spy.mock.calls.filter(
+      ([msg]) => typeof msg === 'string' && msg.startsWith('runJudge:')
+    );
+    assert.strictEqual(judgeLogs.length, 5);
+  } finally {
+    spy.mockRestore();
+    delete process.env.DEBUG_JUDGE;
+    process.chdir(prev);
+  }
 });
 


### PR DESCRIPTION
## Summary
- add DEBUG_JUDGE env flag to guard console logging in runJudge
- test that logging only occurs when DEBUG_JUDGE is true

## Testing
- `npm install --include=dev` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e2bf13bc8321956fdc4d8d4e96c7