### PR TITLE
chore: polyfill TextEncoder/Decoder for Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ const config = {
     ],
   },
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  setupFiles: ['<rootDir>/test/setup.ts'],
   testMatch: [
     '**/test/(q21|judge|customCriteria|evaluateCriteriaPartial|health).test.ts',
   ],

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,4 @@
+import { TextEncoder, TextDecoder } from 'util';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder as any;


### PR DESCRIPTION
## Summary
- add TextEncoder/TextDecoder polyfill in test setup
- configure Jest to load test setup

## Testing
- `npm test -- test/no-export-get-link.test.ts test/editor-disabled.test.ts` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dfeafcb08321a3faa11fce6f2227