### PR TITLE
refactor: migrate tests from node:test to jest

### DIFF
--- a/test/advisor.test.ts
+++ b/test/advisor.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import { generateInquiryFromPlan } from '../src/lib/utils/inquiry';
 

--- a/test/consultant.test.ts
+++ b/test/consultant.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import { mkdtemp, writeFile, readFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';

--- a/test/download-zip.test.ts
+++ b/test/download-zip.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import { test, afterAll } from '@jest/globals';
 import assert from 'node:assert';
 import { GET } from '../src/app/api/download/zip/route.ts';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
@@ -23,7 +23,7 @@ async function ensureTheory(slug: string, v: string) {
   );
 }
 
-test.after(async () => {
+afterAll(async () => {
   await rm(path.join(root, 'QaadiDB'), { recursive: true, force: true });
 });
 

--- a/test/editor-disabled.test.ts
+++ b/test/editor-disabled.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';

--- a/test/gates.test.ts
+++ b/test/gates.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import { runGates } from '../src/lib/workflow';
 

--- a/test/inquiry.test.ts
+++ b/test/inquiry.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import { buildPrompt } from '../src/lib/buildPrompt';
 

--- a/test/journalist.test.ts
+++ b/test/journalist.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import { mkdtemp, writeFile, readFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';

--- a/test/lead.test.ts
+++ b/test/lead.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import { mkdtemp, writeFile, readFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';

--- a/test/manifest-filter.test.ts
+++ b/test/manifest-filter.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import { latestFilesFor, ManifestEntry } from '../src/lib/utils/manifest';
 

--- a/test/no-export-get-link.test.ts
+++ b/test/no-export-get-link.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import { mkdtemp, readFile } from 'node:fs/promises';
 import path from 'node:path';

--- a/test/snapshot-placeholder.test.ts
+++ b/test/snapshot-placeholder.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';

--- a/test/templates-endpoint.test.ts
+++ b/test/templates-endpoint.test.ts
@@ -1,4 +1,4 @@
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
 import { NextRequest } from 'next/server';
 import { GET } from '../src/app/api/templates/route';


### PR DESCRIPTION
## Summary
- use Jest's globals instead of `node:test`
- replace `test.after` with Jest `afterAll`

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dfef801c8321b89aa2b85dc9e7e2