### PR TITLE
Allow optional blank line in lead best items pattern

### DIFF
--- a/test/lead.test.ts
+++ b/test/lead.test.ts
@@ -21,7 +21,10 @@ test('runLead merges plans and highlights best items', async () => {
   const fileContent = await readFile(cmpPath, 'utf8');
   assert.strictEqual(content, fileContent);
   assert.match(fileContent, /# Comparison/);
-  assert.match(fileContent, /## Best Items\n- Task A \(alpha, beta\)\n- Task C \(beta\)/);
+  assert.match(
+    fileContent,
+    /## Best Items\n(?:\n)?- Task A \(alpha, beta\)\n- Task C \(beta\)/,
+  );
   assert.match(fileContent, /## alpha/);
   assert.match(fileContent, /## beta/);
 });


### PR DESCRIPTION
## Summary
- permit an optional blank line after "Best Items" in lead comparison test

## Testing
- `npm test -- test/lead.test.ts` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dfee37148321ba07a32280ca46d2