### PR TITLE
Ensure safety criteria and polyfill TextEncoder in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ const createJestConfig = nextJest({
 /** @type {import('jest').Config} */
 const config = {
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/test/setup.ts'],
   transform: {
     '^.+\\.(ts|tsx)$': [
       'ts-jest',

--- a/src/lib/criteria.ts
+++ b/src/lib/criteria.ts
@@ -33,12 +33,26 @@ async function ensureDirs() {
   await mkdir(ARCHIVE, { recursive: true });
 }
 
+const DEFAULT_CRITERIA: Criterion[] = [
+  {
+    id: "SAFE",
+    description: "Safety compliance",
+    weight: 5,
+    keywords: ["safety", "compliance"],
+    enabled: true,
+    category: "internal",
+    version: 1,
+  },
+];
+
 export async function loadCriteria(): Promise<Criterion[]> {
   try {
     const raw = await readFile(LATEST, "utf-8");
-    return JSON.parse(raw) as Criterion[];
+    const parsed = JSON.parse(raw) as Criterion[];
+    const ids = new Set(parsed.map((c) => c.id));
+    return [...parsed, ...DEFAULT_CRITERIA.filter((c) => !ids.has(c.id))];
   } catch {
-    return [];
+    return [...DEFAULT_CRITERIA];
   }
 }
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,11 @@
+import { TextEncoder, TextDecoder } from 'util';
+
+if (!globalThis.TextEncoder) {
+  // @ts-ignore
+  globalThis.TextEncoder = TextEncoder;
+}
+
+if (!globalThis.TextDecoder) {
+  // @ts-ignore
+  globalThis.TextDecoder = TextDecoder;
+}


### PR DESCRIPTION
## Summary
- include a default "Safety compliance" criterion when loading custom criteria
- polyfill `TextEncoder`/`TextDecoder` for Node test environment and configure Jest to load it

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npx jest --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fed2fbf08321bee4ef90711f07a7