### PR TITLE
Fix criteria path resolution and polyfill TextEncoder in tests

### DIFF
--- a/test/editor-disabled.test.ts
+++ b/test/editor-disabled.test.ts
@@ -2,11 +2,18 @@
 
 import { test } from '@jest/globals';
 import assert from 'node:assert';
-import * as React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
-import Editor from '../src/components/Editor';
 
-test('export and generate buttons require target and lang', () => {
+test('export and generate buttons require target and lang', async () => {
+  const { TextEncoder, TextDecoder } = await import('util');
+  // @ts-ignore
+  global.TextEncoder ??= TextEncoder;
+  // @ts-ignore
+  global.TextDecoder ??= TextDecoder;
+
+  const React = await import('react');
+  const { renderToStaticMarkup } = await import('react-dom/server');
+  const Editor = (await import('../src/components/Editor')).default;
+
   // initial render without target/lang -> buttons disabled
   const initial = renderToStaticMarkup(React.createElement(Editor));
   assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);

--- a/test/no-export-get-link.test.ts
+++ b/test/no-export-get-link.test.ts
@@ -2,11 +2,18 @@
 
 import { test } from '@jest/globals';
 import assert from 'node:assert';
-import * as React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
-import Editor from '../src/components/Editor';
 
-test('editor has no direct GET export link', () => {
+test('editor has no direct GET export link', async () => {
+  const { TextEncoder, TextDecoder } = await import('util');
+  // @ts-ignore
+  global.TextEncoder ??= TextEncoder;
+  // @ts-ignore
+  global.TextDecoder ??= TextDecoder;
+
+  const React = await import('react');
+  const { renderToStaticMarkup } = await import('react-dom/server');
+  const Editor = (await import('../src/components/Editor')).default;
+
   const markup = renderToStaticMarkup(React.createElement(Editor));
   assert.doesNotMatch(markup, /<a[^>]+href="\/api\/export"/);
 });


### PR DESCRIPTION
## Summary
- compute criteria storage paths on demand based on current working directory
- use dynamic imports and util-based TextEncoder/Decoder polyfills in editor tests to avoid runtime errors

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1031c02108321813f339ab6b997dc