### PR TITLE
Ensure unique criteria archives and simplify tests

### DIFF
--- a/src/lib/criteria.ts
+++ b/src/lib/criteria.ts
@@ -65,7 +65,9 @@ export async function loadCriteria(): Promise<Criterion[]> {
 
 async function archive(criteria: Criterion[]) {
   const { archive } = getPaths();
-  const ts = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
+  // Include milliseconds in the archive filename to avoid collisions when
+  // multiple snapshots are saved within the same second.
+  const ts = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 17);
   await writeFile(path.join(archive, `${ts}.json`), JSON.stringify(criteria, null, 2));
 }
 

--- a/test/editor-disabled.test.ts
+++ b/test/editor-disabled.test.ts
@@ -1,4 +1,4 @@
-/** @jest-environment jsdom */
+// Tests run in the default Node environment; no DOM APIs are required.
 
 import { test } from '@jest/globals';
 import assert from 'node:assert';

--- a/test/no-export-get-link.test.ts
+++ b/test/no-export-get-link.test.ts
@@ -1,4 +1,4 @@
-/** @jest-environment jsdom */
+// Tests run in the default Node environment; no DOM APIs are required.
 
 import { test } from '@jest/globals';
 import assert from 'node:assert';


### PR DESCRIPTION
## Summary
- avoid archive filename collisions by including milliseconds
- run editor component tests in default Node environment to remove jsdom dependency

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a10901aeb88321b53e22a611ac6ffd