### PR TITLE
Fix editor button enablement test by mocking useState

### DIFF
--- a/test/editor-disabled.test.ts
+++ b/test/editor-disabled.test.ts
@@ -1,6 +1,6 @@
 // Tests run in the default Node environment; no DOM APIs are required.
 
-import { test } from '@jest/globals';
+import { test, jest } from '@jest/globals';
 import assert from 'node:assert';
 
 test('export and generate buttons require target and lang', async () => {
@@ -12,10 +12,10 @@ test('export and generate buttons require target and lang', async () => {
 
   const React = await import('react');
   const { renderToStaticMarkup } = await import('react-dom/server');
-  const Editor = (await import('../src/components/Editor')).default;
 
   // initial render without target/lang -> buttons disabled
-  const initial = renderToStaticMarkup(React.createElement(Editor));
+  let Editor = (await import('../src/components/Editor')).default;
+  let initial = renderToStaticMarkup(React.createElement(Editor));
   assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
   assert.match(initial, /<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
   assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
@@ -23,14 +23,16 @@ test('export and generate buttons require target and lang', async () => {
   // render with target and lang preset -> buttons enabled
   const origUseState = React.useState;
   let calls = 0;
-  (React as any).useState = (init: any) => {
+  jest.spyOn(React, 'useState').mockImplementation((init: any) => {
     calls++;
     if (calls === 3) return ['revtex', () => {}]; // target
     if (calls === 4) return ['en', () => {}]; // lang
     return origUseState(init);
-  };
+  });
+  jest.resetModules();
+  Editor = (await import('../src/components/Editor')).default;
   const withValues = renderToStaticMarkup(React.createElement(Editor));
-  (React as any).useState = origUseState;
+  (React.useState as any).mockRestore();
 
   assert.doesNotMatch(withValues, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
   assert.doesNotMatch(withValues, /<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);


### PR DESCRIPTION
## Summary
- fix `editor-disabled` test by spying on `React.useState` before re-importing the component so target and language states can be preset

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden fetching @types/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68a10e640c98832182c26e59f4b7bc69