### PR TITLE
chore: polyfill TextEncoder/Decoder for Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ const createJestConfig = nextJest({
 /** @type {import('jest').Config} */
 const config = {
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/test/setup.ts'],
   transform: {
     '^.+\\.(ts|tsx)$': [
       'ts-jest',
@@ -19,9 +20,7 @@ const config = {
     ],
   },
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  testMatch: [
-    '**/test/(q21|judge|customCriteria|evaluateCriteriaPartial|health).test.ts',
-  ],
+  testMatch: ['**/test/**/*.test.ts'],
 };
 
 export default createJestConfig(config);

--- a/test/editor-disabled.test.ts
+++ b/test/editor-disabled.test.ts
@@ -1,12 +1,13 @@
 /** @jest-environment jsdom */
 
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
-import * as React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
-import Editor from '../src/components/Editor';
 
-test('export and generate buttons require target and lang', () => {
+test('export and generate buttons require target and lang', async () => {
+  const React = await import('react');
+  const { renderToStaticMarkup } = await import('react-dom/server');
+  const Editor = (await import('../src/components/Editor')).default;
+
   // initial render without target/lang -> buttons disabled
   const initial = renderToStaticMarkup(React.createElement(Editor));
   assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);

--- a/test/no-export-get-link.test.ts
+++ b/test/no-export-get-link.test.ts
@@ -1,12 +1,13 @@
 /** @jest-environment jsdom */
 
-import test from 'node:test';
+import { test } from '@jest/globals';
 import assert from 'node:assert';
-import * as React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
-import Editor from '../src/components/Editor';
 
-test('editor has no direct GET export link', () => {
+test('editor has no direct GET export link', async () => {
+  const React = await import('react');
+  const { renderToStaticMarkup } = await import('react-dom/server');
+  const Editor = (await import('../src/components/Editor')).default;
+
   const markup = renderToStaticMarkup(React.createElement(Editor));
   assert.doesNotMatch(markup, /<a[^>]+href="\/api\/export"/);
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,6 @@
+// Polyfill TextEncoder and TextDecoder so Jest can run in Node environments
+// where these globals are not defined.
+import { TextEncoder, TextDecoder } from 'util';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder as any;


### PR DESCRIPTION
## Summary
- define TextEncoder and TextDecoder globals in a shared Jest setup
- load the setup file before tests and update jsdom-based tests to use Jest's helpers
- broaden Jest's testMatch to include all tests under the test directory

## Testing
- `npm install --ignore-scripts --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*
- `npm test -- test/no-export-get-link.test.ts test/editor-disabled.test.ts` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dfeafcb08321a3faa11fce6f2227