### PR TITLE
chore(test): use explicit TextEncoder fallback

### DIFF
--- a/test/editor-disabled.test.ts
+++ b/test/editor-disabled.test.ts
@@ -8,9 +8,9 @@ import assert from 'node:assert';
 test('export and generate buttons require target and lang', async () => {
   const { TextEncoder, TextDecoder } = await import('util');
   // @ts-ignore
-  global.TextEncoder ??= TextEncoder;
+  if (!global.TextEncoder) global.TextEncoder = TextEncoder;
   // @ts-ignore
-  global.TextDecoder ??= TextDecoder;
+  if (!global.TextDecoder) global.TextDecoder = TextDecoder;
 
   // initial render without target/lang -> buttons disabled
   let { default: Editor } = await import('../src/components/Editor');


### PR DESCRIPTION
## Summary
- replace nullish assignment with explicit TextEncoder/TextDecoder polyfill in tests

## Testing
- `npm test` *(fails: jest not found; npm install 403 Forbidden for @types/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68a11767cb588321a45b582f1aa3972c