### PR TITLE
feat: guard q21 debug logs

### DIFF
--- a/src/lib/q21.ts
+++ b/src/lib/q21.ts
@@ -106,9 +106,11 @@ export function evaluateQN21(text: string): QN21Result[] {
     const ratio = c.patterns.length === 0 ? 0 : matches / c.patterns.length;
     const score = c.weight * ratio;
     const gap = Math.max(0, c.weight - score);
-    console.log(
-      `evaluateQN21: ${c.code} matches=${matches}, score=${score}, gap=${gap}`
-    );
+    if (process.env.DEBUG_QN21) {
+      console.log(
+        `evaluateQN21: ${c.code} matches=${matches}, score=${score}, gap=${gap}`
+      );
+    }
     return { ...c, score, gap };
   });
 }

--- a/test/q21.test.ts
+++ b/test/q21.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { jest } from '@jest/globals';
 
 import { evaluateQN21, QN21_CRITERIA, summarizeQN21 } from '../src/lib/q21';
 
@@ -107,6 +108,29 @@ test('summarizeQN21 computes totals, max, percentage, and classification', () =>
   assert.strictEqual(summary.max, expectedMax);
   assert.strictEqual(summary.percentage, (expectedTotal / expectedMax) * 100);
   assert.strictEqual(summary.classification, 'needs_improvement');
+});
+
+test('evaluateQN21 logs only when DEBUG_QN21 is true', () => {
+  const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  try {
+    delete process.env.DEBUG_QN21;
+    evaluateQN21('Equation ensures rigor');
+    let logs = spy.mock.calls.filter(
+      ([msg]) => typeof msg === 'string' && msg.startsWith('evaluateQN21:')
+    );
+    assert.strictEqual(logs.length, 0);
+
+    spy.mockClear();
+    process.env.DEBUG_QN21 = 'true';
+    evaluateQN21('Equation ensures rigor');
+    logs = spy.mock.calls.filter(
+      ([msg]) => typeof msg === 'string' && msg.startsWith('evaluateQN21:')
+    );
+    assert.strictEqual(logs.length, QN21_CRITERIA.length);
+  } finally {
+    spy.mockRestore();
+    delete process.env.DEBUG_QN21;
+  }
 });
 
 test('QN21_CRITERIA exposes documented codes, types and weights', () => {


### PR DESCRIPTION
## Summary
- log `evaluateQN21` debug output only when `DEBUG_QN21` env var is set
- test that debug messages appear only with `DEBUG_QN21` enabled

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a117664b0483218213303d075942b8