### PR TITLE
Sanitize slug on initial load

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -55,18 +55,20 @@ export default function Editor() {
   const [slug, setSlug] = useState("default");
   const [v, setV] = useState("default");
 
+  const slugRe = /^[A-Za-z0-9_-]*$/;
+
   useEffect(() => {
     if (typeof window !== "undefined") {
       const parts = window.location.pathname.split("/").filter(Boolean);
       const params = new URLSearchParams(window.location.search);
-      const s = parts[0] || params.get("slug") || "default";
-      const ver = parts[1] || params.get("v") || "default";
+      const sCandidate = parts[0] || params.get("slug") || "default";
+      const verCandidate = parts[1] || params.get("v") || "default";
+      const s = slugRe.test(sCandidate) ? sCandidate : "default";
+      const ver = slugRe.test(verCandidate) ? verCandidate : "default";
       setSlug(s);
       setV(ver);
     }
   }, []);
-
-  const slugRe = /^[A-Za-z0-9_-]*$/;
 
   const snapshotPath = useMemo(() => {
     if (!files.length) return null;


### PR DESCRIPTION
## Summary
- Sanitize `slug` and version values from the URL using existing `slugRe` regex

## Testing
- `node <<'NODE'
const slugRe = /^[A-Za-z0-9_-]*$/;
['good','bad slug!','UPPER_case','foo#'].forEach(s => console.log(s, slugRe.test(s)));
NODE`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a11765cdc0832192de47c5bf20aa58