### PR TITLE
refactor: modularize generation, evaluation, and self‑verification

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { InputSchema, OutputSchema } from "../../../lib/schema/io";
-import { runWithFallback } from "../../../lib/providers/router";
+import { generateText } from "../../../lib/generationService";
 import { freezeText, restoreText, countEquations, FrozenText } from "../../../lib/utils/freeze";
 import { checkIdempotency } from "../../../lib/utils/idempotency";
 import { saveSnapshot } from "../../../lib/saveSnapshot";
@@ -126,7 +126,7 @@ export async function POST(req: NextRequest) {
       { text: string; dir: "rtl" | "ltr" | "mixed" }
     > = {};
     for (const l of langs) {
-      const out = await runWithFallback(
+      const out = await generateText(
         model,
         { openai: openaiKey || undefined, deepseek: deepseekKey || undefined },
         prompts[l],
@@ -186,7 +186,7 @@ export async function POST(req: NextRequest) {
   const eqBefore = frozen.equations.length;
 
   try {
-    const out = await runWithFallback(
+    const out = await generateText(
       input.model === "auto" ? "auto" : (input.model as any),
       { openai: openaiKey || undefined, deepseek: deepseekKey || undefined },
       prompt,

--- a/src/app/api/selftest/route.ts
+++ b/src/app/api/selftest/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
-import { readFile, writeFile, mkdir, readdir } from "fs/promises";
+import { readFile, mkdir, readdir } from "fs/promises";
 import path from "path";
-import crypto from "crypto";
+import { performSelfVerification } from "../../../lib/selfVerificationService";
 
 export const runtime = "nodejs";
 
@@ -12,42 +12,13 @@ const headers = {
   "Access-Control-Allow-Origin": "*"
 };
 
-const roleFns: Record<string, (text: string) => string> = {
-  length: (t) => String(t.length),
-  sha256: (t) => crypto.createHash("sha256").update(t).digest("hex")
-};
-
-function tsFile() {
-  return new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
-}
-
 export async function POST(req: NextRequest) {
   try {
     const { slug, sample } = await req.json();
     if (!slug || typeof sample !== "string") {
       return new Response(JSON.stringify({ error: "invalid_params" }), { status: 400, headers });
     }
-    const base = path.join(process.cwd(), "QaadiVault", `theory-${slug}`);
-    const fpPath = path.join(base, "fingerprints.json");
-    const raw = await readFile(fpPath, "utf-8");
-    const fingerprints = JSON.parse(raw) as Record<string, string>;
-    const deviations: { role: string; expected: string; found: string }[] = [];
-    let matches = 0;
-    for (const role of Object.keys(fingerprints)) {
-      const fn = roleFns[role];
-      const found = fn ? fn(sample) : "";
-      const expected = fingerprints[role];
-      if (found === expected) matches++;
-      else deviations.push({ role, expected, found });
-    }
-    const ratio = Object.keys(fingerprints).length
-      ? matches / Object.keys(fingerprints).length
-      : 0;
-    const testsDir = path.join(base, "tests");
-    await mkdir(testsDir, { recursive: true });
-    const ts = tsFile();
-    const log = { ratio, deviations };
-    await writeFile(path.join(testsDir, `${ts}.json`), JSON.stringify(log, null, 2));
+    const log = await performSelfVerification(slug, sample);
     return new Response(JSON.stringify(log), { status: 200, headers });
   } catch {
     return new Response(JSON.stringify({ error: "fingerprints_not_found" }), { status: 500, headers });

--- a/src/lib/evaluationService.ts
+++ b/src/lib/evaluationService.ts
@@ -1,0 +1,54 @@
+import { evaluateQN21 } from "./q21";
+import { loadCriteria, evaluateCriteria } from "./criteria";
+
+interface ChartCriterion {
+  id: number;
+  name: string;
+  score: number;
+  gap: number;
+  type?: "internal" | "external" | "advisory";
+  covered?: boolean;
+}
+
+export async function evaluateText(text: string) {
+  const qn21Results = evaluateQN21(text);
+  const custom = await loadCriteria();
+  const customResults = evaluateCriteria(text, custom);
+
+  const qn21Criteria: ChartCriterion[] = qn21Results.map((c, i) => ({
+    id: i + 1,
+    name: c.description || c.code,
+    score: c.score,
+    gap: Math.max(0, c.weight - c.score),
+    type: c.type,
+    covered: c.score === c.weight,
+  }));
+  const customCriteria: ChartCriterion[] = customResults.map((c, i) => ({
+    id: qn21Results.length + i + 1,
+    name: c.description || c.id,
+    score: c.score,
+    gap: Math.max(0, c.weight - c.score),
+    type: c.category,
+    covered: c.score === c.weight,
+  }));
+  const combined: ChartCriterion[] = [...qn21Criteria, ...customCriteria];
+
+  const total = [...qn21Results, ...customResults].reduce((s, c) => s + c.score, 0);
+  const max = [...qn21Results, ...customResults].reduce((s, c) => s + c.weight, 0);
+  const percentage = max === 0 ? 0 : (total / max) * 100;
+  let classification: "accepted" | "needs_improvement" | "weak" = "weak";
+  if (percentage >= 80) classification = "accepted";
+  else if (percentage >= 60) classification = "needs_improvement";
+  const gaps = combined
+    .filter((c) => c.gap > 0)
+    .map((c) => ({ id: c.id, name: c.name, gap: c.gap }));
+
+  return {
+    verdict: "approved" as const,
+    criteria: combined,
+    score: { total, max, percentage },
+    percentage,
+    gaps,
+    classification,
+  };
+}

--- a/src/lib/generationService.ts
+++ b/src/lib/generationService.ts
@@ -1,0 +1,19 @@
+import { runWithFallback } from "./providers/router";
+
+export type ProviderModel = "openai" | "deepseek" | "auto";
+export interface ProviderKeys { openai?: string; deepseek?: string }
+
+export async function generateText(
+  model: ProviderModel,
+  keys: ProviderKeys,
+  prompt: string,
+  maxTokens: number,
+  runner: (
+    model: ProviderModel,
+    keys: ProviderKeys,
+    prompt: string,
+    maxTokens: number
+  ) => Promise<any> = runWithFallback
+) {
+  return runner(model, keys, prompt, maxTokens);
+}

--- a/src/lib/selfVerificationService.ts
+++ b/src/lib/selfVerificationService.ts
@@ -1,0 +1,37 @@
+import { readFile, writeFile, mkdir } from "fs/promises";
+import path from "path";
+import crypto from "crypto";
+
+const roleFns: Record<string, (text: string) => string> = {
+  length: (t) => String(t.length),
+  sha256: (t) => crypto.createHash("sha256").update(t).digest("hex"),
+};
+
+function tsFile() {
+  return new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
+}
+
+export async function performSelfVerification(slug: string, sample: string) {
+  const base = path.join(process.cwd(), "QaadiVault", `theory-${slug}`);
+  const fpPath = path.join(base, "fingerprints.json");
+  const raw = await readFile(fpPath, "utf-8");
+  const fingerprints = JSON.parse(raw) as Record<string, string>;
+  const deviations: { role: string; expected: string; found: string }[] = [];
+  let matches = 0;
+  for (const role of Object.keys(fingerprints)) {
+    const fn = roleFns[role];
+    const found = fn ? fn(sample) : "";
+    const expected = fingerprints[role];
+    if (found === expected) matches++;
+    else deviations.push({ role, expected, found });
+  }
+  const ratio = Object.keys(fingerprints).length
+    ? matches / Object.keys(fingerprints).length
+    : 0;
+  const testsDir = path.join(base, "tests");
+  await mkdir(testsDir, { recursive: true });
+  const ts = tsFile();
+  const log = { ratio, deviations };
+  await writeFile(path.join(testsDir, `${ts}.json`), JSON.stringify(log, null, 2));
+  return log;
+}

--- a/test/evaluationService.test.ts
+++ b/test/evaluationService.test.ts
@@ -1,0 +1,12 @@
+import { test } from '@jest/globals';
+import assert from 'node:assert';
+import { evaluateText } from '../src/lib/evaluationService.ts';
+
+test('evaluateText combines QN21 and custom criteria', async () => {
+  const text = 'Equations ensure safety and compliance in our methodology.';
+  const result = await evaluateText(text);
+  assert.ok(Array.isArray(result.criteria));
+  const safety = result.criteria.find(c => c.name.toLowerCase().includes('safety'));
+  assert.ok(safety);
+  assert.ok((safety as any).score > 0);
+});

--- a/test/generationService.test.ts
+++ b/test/generationService.test.ts
@@ -1,0 +1,11 @@
+import { test, jest } from '@jest/globals';
+import assert from 'node:assert';
+import { generateText } from '../src/lib/generationService.ts';
+
+test('generateText delegates to provided runner', async () => {
+  const runner = jest.fn().mockResolvedValue({ text: 'hi' });
+  const res = await generateText('auto', {}, 'prompt', 5, runner);
+  assert.deepStrictEqual(res, { text: 'hi' });
+  assert.strictEqual(runner.mock.calls.length, 1);
+  assert.deepStrictEqual(runner.mock.calls[0], ['auto', {}, 'prompt', 5]);
+});

--- a/test/selfVerificationService.test.ts
+++ b/test/selfVerificationService.test.ts
@@ -1,0 +1,21 @@
+import { test } from '@jest/globals';
+import assert from 'node:assert';
+import { mkdtemp, cp } from 'fs/promises';
+import path from 'path';
+import { tmpdir } from 'os';
+import { performSelfVerification } from '../src/lib/selfVerificationService.ts';
+
+test('performSelfVerification matches stored fingerprints', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  try {
+    const src = path.join(prev, 'docs', 'examples', 'QaadiVault');
+    await cp(src, path.join(dir, 'QaadiVault'), { recursive: true });
+    const log = await performSelfVerification('demo', '');
+    assert.strictEqual(log.ratio, 1);
+    assert.deepStrictEqual(log.deviations, []);
+  } finally {
+    process.chdir(prev);
+  }
+});


### PR DESCRIPTION
## Summary
- add `generationService`, `evaluationService`, and `selfVerificationService` in `src/lib`
- update judge worker and API routes to use the new services
- introduce unit tests for the new service layer

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a67577ec83219a9052c7f687fd07