### PR TITLE
Add language selector with i18n and RTL support

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import Header from "../../components/Header";
+import Footer from "../../components/Footer";
+import { useLanguage } from "../../components/LangDirProvider";
+
+export default function AboutPage() {
+  const { t } = useLanguage();
+  return (
+    <>
+      <Header />
+      <main style={{ padding: 16 }}>{t("about.content")}</main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,9 +28,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="manifest" href="/manifest.webmanifest" />
       </head>
       <body>
-        <LangDirProvider />
-        <ServiceWorkerRegister />
-        <div className="wrapper">{children}</div>
+        <LangDirProvider>
+          <ServiceWorkerRegister />
+          <div className="wrapper">{children}</div>
+        </LangDirProvider>
       </body>
     </html>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,11 +1,16 @@
+"use client";
+
+import { useLanguage } from "./LangDirProvider";
+
 export default function Footer() {
+  const { t } = useLanguage();
   return (
-    <footer className="footer" style={{marginTop:24, textAlign:"center"}}>
+    <footer className="footer" style={{ marginTop: 24, textAlign: "center" }}>
       <small>© {new Date().getFullYear()} Qaadi</small>
-      <span style={{margin: "0 8px"}}>|</span>
-      <a href="/templates">القوالب</a>
-      <span style={{margin: "0 8px"}}>|</span>
-      <a href="mailto:contact@qaadi.live">اتصل بنا</a>
+      <span style={{ margin: "0 8px" }}>|</span>
+      <a href="/templates">{t("footer.templates")}</a>
+      <span style={{ margin: "0 8px" }}>|</span>
+      <a href="mailto:contact@qaadi.live">{t("footer.contact")}</a>
     </footer>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,16 @@
+"use client";
+
+import LanguageSelector from "./LanguageSelector";
+import { useLanguage } from "./LangDirProvider";
+
 export default function Header() {
+  const { t } = useLanguage();
   return (
-    <h1 className="h1"><span className="badge">⚖️</span> Qaadi Live</h1>
+    <header style={{ display: "flex", alignItems: "center" }}>
+      <h1 className="h1" style={{ marginRight: 8 }}>
+        <span className="badge">⚖️</span> {t("header.title")}
+      </h1>
+      <LanguageSelector />
+    </header>
   );
 }

--- a/src/components/LangDirProvider.tsx
+++ b/src/components/LangDirProvider.tsx
@@ -1,42 +1,58 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import en from "../i18n/en.json";
+import ar from "../i18n/ar.json";
 
-export default function LangDirProvider() {
-  const [lang, setLang] = useState(
-    typeof navigator !== "undefined" ? navigator.language.split("-")[0] : "en"
-  );
-  const [dir, setDir] = useState<"ltr" | "rtl">("ltr");
+type Lang = "en" | "ar";
+
+const translations: Record<Lang, Record<string, string>> = { en, ar };
+
+interface LangContext {
+  lang: Lang;
+  setLang: (lang: Lang) => void;
+  t: (key: string) => string;
+}
+
+const LanguageContext = createContext<LangContext>({
+  lang: "en",
+  setLang: () => {},
+  t: (key) => key,
+});
+
+export function useLanguage() {
+  return useContext(LanguageContext);
+}
+
+export default function LangDirProvider({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState<Lang>("en");
 
   useEffect(() => {
     try {
-      const l = localStorage.getItem("lang");
-      const d = localStorage.getItem("dir") as "ltr" | "rtl" | null;
-      if (l) setLang(l);
-      if (d) setDir(d);
+      const stored = localStorage.getItem("lang");
+      if (stored === "ar" || stored === "en") setLang(stored);
+      else if (typeof navigator !== "undefined") {
+        const nav = navigator.language.split("-")[0];
+        setLang(nav === "ar" ? "ar" : "en");
+      }
     } catch {}
-
-    const onStorage = (e: StorageEvent) => {
-      if (e.key === "lang" && e.newValue) setLang(e.newValue);
-    };
-    window.addEventListener("storage", onStorage);
-    return () => window.removeEventListener("storage", onStorage);
   }, []);
 
   useEffect(() => {
-    const rtlLangs = new Set(["ar", "he", "fa", "ur"]);
-    const newDir: "ltr" | "rtl" = rtlLangs.has(lang) ? "rtl" : "ltr";
-    setDir(newDir);
+    const dir = lang === "ar" ? "rtl" : "ltr";
+    document.documentElement.lang = lang;
+    document.documentElement.dir = dir;
     try {
       localStorage.setItem("lang", lang);
-      localStorage.setItem("dir", newDir);
+      localStorage.setItem("dir", dir);
     } catch {}
   }, [lang]);
 
-  useEffect(() => {
-    document.documentElement.lang = lang;
-    document.documentElement.dir = dir;
-  }, [lang, dir]);
+  const t = (key: string) => translations[lang][key] || key;
 
-  return null;
+  return (
+    <LanguageContext.Provider value={{ lang, setLang, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
 }

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useLanguage } from "./LangDirProvider";
+
+export default function LanguageSelector() {
+  const { lang, setLang } = useLanguage();
+  return (
+    <select
+      value={lang}
+      onChange={(e) => setLang(e.target.value as "en" | "ar")}
+      style={{ marginLeft: "auto" }}
+    >
+      <option value="en">EN</option>
+      <option value="ar">AR</option>
+    </select>
+  );
+}

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -1,0 +1,6 @@
+{
+  "header.title": "قاضي لايف",
+  "footer.templates": "القوالب",
+  "footer.contact": "اتصل بنا",
+  "about.content": "هذه صفحة حول." 
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,6 @@
+{
+  "header.title": "Qaadi Live",
+  "footer.templates": "Templates",
+  "footer.contact": "Contact Us",
+  "about.content": "This is the about page."
+}


### PR DESCRIPTION
## Summary
- provide context-based language and direction provider with JSON translations
- add language selector in header and internationalized footer
- introduce example about page demonstrating i18n use

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a67464f88321b862f5bf19336868