### PR TITLE
feat: add chart.js charts for QN-21 progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "migrate-registry": "ts-node scripts/migrate-registry.ts"
   },
   "dependencies": {
+    "chart.js": "^4.4.3",
     "next": "14.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/app/judge/page.tsx
+++ b/src/app/judge/page.tsx
@@ -1,0 +1,34 @@
+import Header from "../../components/Header";
+import Footer from "../../components/Footer";
+import QN21Radar from "../../components/QN21Radar";
+import QN21Timeline from "../../components/QN21Timeline";
+
+export default function Page() {
+  const radar = [
+    { label: "QN-21-6", score: 4 },
+    { label: "QN-21-7", score: 3 },
+    { label: "QN-21-8", score: 5 },
+    { label: "QN-21-9", score: 2 },
+    { label: "QN-21-10", score: 4 }
+  ];
+  const timeline = [
+    { time: "01", value: 2 },
+    { time: "02", value: 3 },
+    { time: "03", value: 4 },
+    { time: "04", value: 5 },
+    { time: "05", value: 6 }
+  ];
+  return (
+    <>
+      <Header />
+      <div className="card">
+        <QN21Radar data={radar} />
+        <div style={{ marginTop: 16 }}>
+          <QN21Timeline data={timeline} />
+        </div>
+      </div>
+      <Footer />
+    </>
+  );
+}
+

--- a/src/app/lead/page.tsx
+++ b/src/app/lead/page.tsx
@@ -1,0 +1,34 @@
+import Header from "../../components/Header";
+import Footer from "../../components/Footer";
+import QN21Radar from "../../components/QN21Radar";
+import QN21Timeline from "../../components/QN21Timeline";
+
+export default function Page() {
+  const radar = [
+    { label: "QN-21-11", score: 5 },
+    { label: "QN-21-12", score: 4 },
+    { label: "QN-21-13", score: 3 },
+    { label: "QN-21-14", score: 4 },
+    { label: "QN-21-15", score: 2 }
+  ];
+  const timeline = [
+    { time: "01", value: 3 },
+    { time: "02", value: 4 },
+    { time: "03", value: 5 },
+    { time: "04", value: 6 },
+    { time: "05", value: 7 }
+  ];
+  return (
+    <>
+      <Header />
+      <div className="card">
+        <QN21Radar data={radar} />
+        <div style={{ marginTop: 16 }}>
+          <QN21Timeline data={timeline} />
+        </div>
+      </div>
+      <Footer />
+    </>
+  );
+}
+

--- a/src/app/secretary/page.tsx
+++ b/src/app/secretary/page.tsx
@@ -1,0 +1,34 @@
+import Header from "../../components/Header";
+import Footer from "../../components/Footer";
+import QN21Radar from "../../components/QN21Radar";
+import QN21Timeline from "../../components/QN21Timeline";
+
+export default function Page() {
+  const radar = [
+    { label: "QN-21-1", score: 3 },
+    { label: "QN-21-2", score: 4 },
+    { label: "QN-21-3", score: 2 },
+    { label: "QN-21-4", score: 5 },
+    { label: "QN-21-5", score: 3 }
+  ];
+  const timeline = [
+    { time: "01", value: 1 },
+    { time: "02", value: 2 },
+    { time: "03", value: 3 },
+    { time: "04", value: 4 },
+    { time: "05", value: 5 }
+  ];
+  return (
+    <>
+      <Header />
+      <div className="card">
+        <QN21Radar data={radar} />
+        <div style={{ marginTop: 16 }}>
+          <QN21Timeline data={timeline} />
+        </div>
+      </div>
+      <Footer />
+    </>
+  );
+}
+

--- a/src/components/QN21Radar.tsx
+++ b/src/components/QN21Radar.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+interface Result {
+  label: string;
+  score: number;
+}
+
+interface Props {
+  data: Result[];
+}
+
+export default function QN21Radar({ data }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    let chart: any;
+    const load = async () => {
+      const { Chart } = await import("chart.js/auto");
+      if (!canvasRef.current) return;
+      const labels = data.map(d => d.label);
+      const values = data.map(d => d.score);
+      chart = new Chart(canvasRef.current, {
+        type: "radar",
+        data: {
+          labels,
+          datasets: [
+            {
+              data: values,
+              backgroundColor: "rgba(16,185,129,0.2)",
+              borderColor: "#10b981",
+              pointBackgroundColor: "#10b981"
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: { r: { beginAtZero: true } }
+        }
+      });
+    };
+    load();
+    return () => chart?.destroy?.();
+  }, [data]);
+
+  return <canvas ref={canvasRef} />;
+}
+

--- a/src/components/QN21Timeline.tsx
+++ b/src/components/QN21Timeline.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+interface Point {
+  time: string;
+  value: number;
+}
+
+interface Props {
+  data: Point[];
+}
+
+export default function QN21Timeline({ data }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    let chart: any;
+    const load = async () => {
+      const { Chart } = await import("chart.js/auto");
+      if (!canvasRef.current) return;
+      const labels = data.map(d => d.time);
+      const values = data.map(d => d.value);
+      chart = new Chart(canvasRef.current, {
+        type: "line",
+        data: {
+          labels,
+          datasets: [
+            {
+              data: values,
+              borderColor: "#3b82f6",
+              fill: false
+            }
+          ]
+        },
+        options: {
+          plugins: { legend: { display: false } },
+          scales: { y: { beginAtZero: true } }
+        }
+      });
+    };
+    load();
+    return () => chart?.destroy?.();
+  }, [data]);
+
+  return <canvas ref={canvasRef} />;
+}
+

--- a/src/components/ScoreCharts.tsx
+++ b/src/components/ScoreCharts.tsx
@@ -22,19 +22,7 @@ export default function ScoreCharts({ criteria }: Props) {
     let radar: any;
 
     const load = async () => {
-      if (typeof window === "undefined") return;
-      const w = window as any;
-      if (!w.Chart) {
-        await new Promise((resolve, reject) => {
-          const s = document.createElement("script");
-          s.src = "https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js";
-          s.onload = resolve;
-          s.onerror = reject;
-          document.head.appendChild(s);
-        }).catch(() => {});
-      }
-      const Chart = (window as any).Chart;
-      if (!Chart) return;
+      const { Chart } = await import("chart.js/auto");
 
       const labels = criteria.map(c => c.name);
       const scores = criteria.map(c => c.score);


### PR DESCRIPTION
## Summary
- embed chart.js and stop loading it from CDN
- add reusable QN-21 radar and timeline chart components
- create separate role pages wiring up the new charts

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/chart.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a67171d4832182ff48974c75fe4c