### PR TITLE
feat: restore judge page layout

### DIFF
--- a/src/app/judge/page.tsx
+++ b/src/app/judge/page.tsx
@@ -2,6 +2,7 @@ import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 import QN21Radar from "../../components/QN21Radar";
 import QN21Timeline from "../../components/QN21Timeline";
+import Judge from "../../components/Judge";
 
 export default function Page() {
   const radar = [
@@ -26,6 +27,7 @@ export default function Page() {
         <div style={{ marginTop: 16 }}>
           <QN21Timeline data={timeline} />
         </div>
+        <Judge />
       </div>
       <Footer />
     </>

--- a/src/components/Judge.tsx
+++ b/src/components/Judge.tsx
@@ -1,0 +1,5 @@
+"use client";
+import Editor from "./Editor";
+export default function Judge() {
+  return <Editor />;
+}


### PR DESCRIPTION
## Summary
- add Judge component wrapper around Editor
- include Judge in judge page alongside QN21 charts and layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bf3b40848321b2ea58924d867466