### PR TITLE
feat: add secretary component

### DIFF
--- a/src/app/secretary/page.tsx
+++ b/src/app/secretary/page.tsx
@@ -2,6 +2,7 @@ import Header from "../../components/Header";
 import Footer from "../../components/Footer";
 import QN21Radar from "../../components/QN21Radar";
 import QN21Timeline from "../../components/QN21Timeline";
+import Secretary from "../../components/Secretary";
 
 export default function Page() {
   const radar = [
@@ -22,6 +23,7 @@ export default function Page() {
     <>
       <Header />
       <div className="card">
+        <Secretary />
         <QN21Radar data={radar} />
         <div style={{ marginTop: 16 }}>
           <QN21Timeline data={timeline} />

--- a/src/components/Secretary.tsx
+++ b/src/components/Secretary.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function Secretary() {
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <p>Secretary component placeholder.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- restore header/footer and QN21 charts on secretary page
- embed placeholder Secretary component within page card

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bf3963ec83219c86081e52de5a20