### PR TITLE
feat: add header navigation links

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import LanguageSelector from "./LanguageSelector";
 import { useLanguage } from "./LangDirProvider";
 
@@ -10,6 +11,13 @@ export default function Header() {
       <h1 className="h1" style={{ marginRight: 8 }}>
         <span className="badge">⚖️</span> {t("header.title")}
       </h1>
+      <nav style={{ display: "flex", gap: 8 }}>
+        <Link href="/secretary">Secretary</Link>
+        <Link href="/judge">Judge</Link>
+        <Link href="/consultant">Consultant</Link>
+        <Link href="/department-head">Department Head</Link>
+        <Link href="/journalist">Journalist</Link>
+      </nav>
       <LanguageSelector />
     </header>
   );


### PR DESCRIPTION
## Summary
- restore client side header with language support
- add role navigation links to header

## Testing
- `npm install` *(fails: E403 Forbidden for @types/jest)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bf37a0d083218a4e750d38e3dc6c