### PR TITLE
feat: enforce mandatory qn21 criteria

### DIFF
--- a/src/lib/workflow/qnGate.ts
+++ b/src/lib/workflow/qnGate.ts
@@ -1,6 +1,7 @@
 export interface QN21Criterion {
   id: number;
   score: number;
+  name?: string;
 }
 
 export interface QN21Report {
@@ -11,7 +12,7 @@ export interface QN21Report {
 export interface QN21GateResult {
   allowed: boolean;
   percentage: number;
-  failed: number[];
+  failed: Array<number | string>;
 }
 
 /**
@@ -34,9 +35,18 @@ export function gateQn21(
   }
   const max = report.criteria.length * 10;
   const percentage = max > 0 ? (report.score_total / max) * 100 : 0;
-  const failed = report.criteria
+  const failed: Array<number | string> = report.criteria
     .filter((c) => critical.includes(c.id) && c.score < criticalThreshold)
     .map((c) => c.id);
+
+  const mandatory = ["equations", "definitions", "dimensional"];
+  for (const name of mandatory) {
+    const crit = report.criteria.find((c) => c.name === name);
+    if (!crit || crit.score < 1) {
+      failed.push(name);
+    }
+  }
+
   const allowed = failed.length === 0 && percentage >= minTotal;
   return { allowed, percentage, failed };
 }

--- a/test/qn21-gate.test.ts
+++ b/test/qn21-gate.test.ts
@@ -6,9 +6,9 @@ test('gateQn21 blocks when total percentage below threshold', () => {
   const report = {
     score_total: 15,
     criteria: [
-      { id: 1, score: 5 },
-      { id: 2, score: 5 },
-      { id: 3, score: 5 },
+      { id: 1, name: 'equations', score: 5 },
+      { id: 3, name: 'dimensional', score: 5 },
+      { id: 13, name: 'definitions', score: 5 },
     ],
   };
   const gate = gateQn21(report);
@@ -18,11 +18,11 @@ test('gateQn21 blocks when total percentage below threshold', () => {
 
 test('gateQn21 blocks when critical criterion fails', () => {
   const report = {
-    score_total: 66,
+    score_total: 73,
     criteria: [
-      { id: 1, score: 3 },
+      { id: 1, name: 'equations', score: 3 },
       { id: 2, score: 7 },
-      { id: 3, score: 7 },
+      { id: 3, name: 'dimensional', score: 7 },
       { id: 4, score: 7 },
       { id: 5, score: 7 },
       { id: 6, score: 7 },
@@ -30,9 +30,48 @@ test('gateQn21 blocks when critical criterion fails', () => {
       { id: 8, score: 7 },
       { id: 9, score: 7 },
       { id: 10, score: 7 },
+      { id: 13, name: 'definitions', score: 7 },
     ],
   };
   const gate = gateQn21(report, [1]);
   assert.strictEqual(gate.allowed, false);
   assert.deepStrictEqual(gate.failed, [1]);
+});
+
+test('gateQn21 blocks when mandatory criteria are below minimum', () => {
+  const report = {
+    score_total: 60,
+    criteria: [
+      { id: 1, name: 'equations', score: 0 },
+      { id: 3, name: 'dimensional', score: 10 },
+      { id: 13, name: 'definitions', score: 10 },
+      { id: 2, score: 10 },
+      { id: 4, score: 10 },
+      { id: 5, score: 10 },
+      { id: 6, score: 10 },
+    ],
+  };
+  const gate = gateQn21(report);
+  assert.strictEqual(gate.allowed, false);
+  assert.deepStrictEqual(gate.failed, ['equations']);
+});
+
+test('gateQn21 allows when all mandatory criteria meet minimum', () => {
+  const report = {
+    score_total: 71,
+    criteria: [
+      { id: 1, name: 'equations', score: 1 },
+      { id: 3, name: 'dimensional', score: 10 },
+      { id: 13, name: 'definitions', score: 10 },
+      { id: 2, score: 10 },
+      { id: 4, score: 10 },
+      { id: 5, score: 10 },
+      { id: 6, score: 10 },
+      { id: 7, score: 10 },
+    ],
+  };
+  const gate = gateQn21(report);
+  assert.strictEqual(gate.allowed, true);
+  assert.deepStrictEqual(gate.failed, []);
+  assert.ok(gate.percentage >= 60);
 });


### PR DESCRIPTION
## Summary
- require equations, definitions, and dimensional criteria to score at least 1 in QN21 gate
- add tests for mandatory QN21 criteria and overall success/failure scenarios

## Testing
- `npm test test/qn21-gate.test.ts` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b66f459c8321a628c20f8138d756