### PR TITLE
Check P0 in consultant plan and protect journalist math

### DIFF
--- a/test/journalist.test.ts
+++ b/test/journalist.test.ts
@@ -12,7 +12,7 @@ test('runJournalist creates multilingual summaries and reports', async () => {
   try {
     const paperDir = path.join(dir, 'paper');
     await mkdir(paperDir, { recursive: true });
-    const comparison = 'Result with equation $E=mc^2$.';
+    const comparison = 'Result with equation $E=mc^2$ and $$a^2+b^2=c^2$$.';
     await writeFile(path.join(paperDir, 'comparison.md'), comparison, 'utf8');
 
     const content = await runJournalist();
@@ -26,8 +26,13 @@ test('runJournalist creates multilingual summaries and reports', async () => {
     ];
     for (const f of files) {
       const fc = await readFile(path.join(paperDir, f), 'utf8');
-      assert.match(fc, /E=mc\^2/);
+      assert.match(fc, /\\(E=mc\^2\\)/);
+      assert.match(fc, /\\[a\^2\+b\^2=c\^2\\]/);
     }
+    const enSummary = await readFile(path.join(paperDir, 'summary.en.md'), 'utf8');
+    const arSummary = await readFile(path.join(paperDir, 'summary.ar.md'), 'utf8');
+    assert.match(enSummary, /dir="ltr"/);
+    assert.match(arSummary, /dir="rtl"/);
     assert.strictEqual(content, await readFile(path.join(paperDir, 'summary.md'), 'utf8'));
   } finally {
     process.chdir(prev);


### PR DESCRIPTION
## Summary
- prevent exports when consultant plan includes P0 items and verify before zipping
- wrap journalist summaries with KaTeX-style math protection and correct text direction
- add tests for KaTeX wrapping and RTL/LTR direction in journalist outputs

## Testing
- `npm install` *(fails: 403 Forbidden for @types/jest)*
- `npm test -- test/journalist.test.ts` *(fails: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a3b67406188321a03ee853ada3454d