### PR TITLE
Clone provider keys before invoking runner

### DIFF
--- a/src/lib/generationService.ts
+++ b/src/lib/generationService.ts
@@ -15,5 +15,5 @@ export async function generateText(
     maxTokens: number
   ) => Promise<any> = runWithFallback
 ) {
-  return runner(model, keys, prompt, maxTokens);
+  return runner(model, { ...keys }, prompt, maxTokens);
 }

--- a/test/generationService.test.ts
+++ b/test/generationService.test.ts
@@ -4,8 +4,13 @@ import { generateText } from '../src/lib/generationService.ts';
 
 test('generateText delegates to provided runner', async () => {
   const runner = jest.fn().mockResolvedValue({ text: 'hi' });
-  const res = await generateText('auto', {}, 'prompt', 5, runner);
+  const keys = Object.create(null);
+  const res = await generateText('auto', keys, 'prompt', 5, runner);
   assert.deepStrictEqual(res, { text: 'hi' });
   assert.strictEqual(runner.mock.calls.length, 1);
   assert.deepStrictEqual(runner.mock.calls[0], ['auto', {}, 'prompt', 5]);
+  assert.strictEqual(
+    Object.getPrototypeOf(runner.mock.calls[0][1]),
+    Object.prototype
+  );
 });


### PR DESCRIPTION
## Summary
- Clone `ProviderKeys` via spread before passing to the runner in `generateText`.
- Test that generated keys object uses `Object.prototype` rather than a null prototype.

## Testing
- `npm test -- test/generationService.test.ts` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c1d8b09c8321a9e1506db56cbf53