### PR TITLE
feat(head): make sessions limit configurable via env

### DIFF
--- a/docs/head.md
+++ b/docs/head.md
@@ -1,7 +1,8 @@
 # Head Orchestrator
 
-The `head` worker manages up to ten concurrent secretary sessions. Each
-session is isolated by `card_id` and stores its vectors under
+The `head` worker manages up to ten concurrent secretary sessions by default.
+You can override this limit by setting the `HEAD_MAX_SESSIONS` environment
+variable. Each session is isolated by `card_id` and stores its vectors under
 `/vector_db/qaadi_sec_<card_id>`.
 
 ## API usage
@@ -29,6 +30,6 @@ const session = await runHead({ card_id: 'abc123', user: 'alice', nonce: '1' });
 console.log(session.session_id);
 ```
 
-Remember to keep fewer than ten sessions active at once. Exceeding this
-limit will throw an error.
+Remember to keep fewer than the configured maximum (default ten) sessions active
+at once. Exceeding this limit will throw an error.
 

--- a/src/lib/workers/head.ts
+++ b/src/lib/workers/head.ts
@@ -2,7 +2,7 @@ import { mkdir } from "fs/promises";
 import path from "path";
 import crypto from "crypto";
 
-const MAX_SESSIONS = 10;
+const MAX_SESSIONS = Number(process.env.HEAD_MAX_SESSIONS) || 10;
 
 interface SessionInfo {
   session_id: string;


### PR DESCRIPTION
## Summary
- allow overriding head session cap with `HEAD_MAX_SESSIONS` env var
- document how to set a custom sessions limit

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c1d149748321a4f5e152510f3948