### PR TITLE
Add conditional debug logging to judge worker

### DIFF
--- a/src/lib/workers/judge.ts
+++ b/src/lib/workers/judge.ts
@@ -3,6 +3,14 @@ import path from "path";
 import { evaluateText } from "../evaluationService";
 
 export async function runJudge(text?: string) {
+  const debug = (msg: string) => {
+    if (process.env.DEBUG_JUDGE) {
+      console.log(`runJudge: ${msg}`);
+    }
+  };
+
+  debug("start");
+
   let content = text;
   if (content === undefined) {
     try {
@@ -16,10 +24,14 @@ export async function runJudge(text?: string) {
     }
   }
 
+  debug(`input size ${content.length}`);
+  debug("evaluation start");
   const result = await evaluateText(content);
 
   const filePath = path.join(process.cwd(), "paper", "judge.json");
+  debug(`write path ${filePath}`);
   await mkdir(path.dirname(filePath), { recursive: true });
   await writeFile(filePath, JSON.stringify(result, null, 2), "utf8");
+  debug("completion");
   return result;
 }


### PR DESCRIPTION
## Summary
- add `runJudge` debug logger gated by `DEBUG_JUDGE`
- log start, input size, evaluation start, write path, and completion

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c1d9b568832193dab3059617330d