### PR TITLE
feat: cleanup head sessions

### DIFF
--- a/docs/head.md
+++ b/docs/head.md
@@ -27,8 +27,17 @@ import { runHead } from '../src/lib/workers';
 
 const session = await runHead({ card_id: 'abc123', user: 'alice', nonce: '1' });
 console.log(session.session_id);
+
+// When finished, end the session and remove its vectors
+await endHead('abc123');
 ```
 
 Remember to keep fewer than ten sessions active at once. Exceeding this
 limit will throw an error.
+
+### Cleaning up
+
+The head worker exposes a `cleanupHead(card_id)` helper that removes the
+vector directory for a given card. `endHead` calls this internally, but
+you can also invoke `cleanupHead` directly to purge leftover session data.
 

--- a/src/lib/workers/head.ts
+++ b/src/lib/workers/head.ts
@@ -1,4 +1,4 @@
-import { mkdir } from "fs/promises";
+import { mkdir, rm } from "fs/promises";
 import path from "path";
 import crypto from "crypto";
 
@@ -36,7 +36,15 @@ export async function runHead(opts: {
   return info;
 }
 
-export function endHead(card_id: string) {
+export async function cleanupHead(card_id: string) {
+  const info = sessions.get(card_id);
+  if (info) {
+    await rm(info.vectorPath, { recursive: true, force: true });
+  }
+}
+
+export async function endHead(card_id: string) {
+  await cleanupHead(card_id);
   sessions.delete(card_id);
 }
 
@@ -57,7 +65,7 @@ export async function exportHead<T>(
     return await exporter();
   } finally {
     for (const id of ids) {
-      endHead(id);
+      await endHead(id);
     }
   }
 }

--- a/src/lib/workers/index.ts
+++ b/src/lib/workers/index.ts
@@ -7,6 +7,7 @@ export { runJournalist } from "./journalist";
 export {
   runHead,
   endHead,
+  cleanupHead,
   resetHead,
   activeHeadSessions,
   exportHead,

--- a/src/lib/workers/researchCenter.ts
+++ b/src/lib/workers/researchCenter.ts
@@ -17,7 +17,7 @@ export async function runResearchCenter(
         await runResearchSecretary(id, cardPlans[id]);
         sessions.push(id);
       } catch (err) {
-        endHead(id);
+        await endHead(id);
         throw err;
       }
     }

--- a/test/head-isolation.test.ts
+++ b/test/head-isolation.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@jest/globals';
 import {
   runHead,
+  endHead,
   resetHead,
   runResearchCenter,
   activeHeadSessions,
@@ -24,7 +25,8 @@ test('AT-1/AT-5 vector store isolation', async () => {
   }
   await expect(runHead({ card_id: 'a11', user: 'u', nonce: 'n1' })).rejects.toThrow();
   for (let i = 1; i <= 10; i++) {
-    await rm(path.join('/vector_db', `qaadi_sec_a${i}`), { recursive: true, force: true });
+    await endHead(`a${i}`);
+    await expect(stat(path.join('/vector_db', `qaadi_sec_a${i}`))).rejects.toThrow();
   }
   resetHead();
 });
@@ -47,6 +49,8 @@ test('research center prevents data leakage between cards', async () => {
   expect(cmp).toContain('Alpha item');
   expect(cmp).toContain('Beta item');
   expect(activeHeadSessions()).toEqual([]);
+  await expect(stat(path.join('/vector_db', 'qaadi_sec_alpha'))).rejects.toThrow();
+  await expect(stat(path.join('/vector_db', 'qaadi_sec_beta'))).rejects.toThrow();
   await rm(dir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary
- add `cleanupHead` to remove head session directories
- ensure `endHead` awaits cleanup and export helper
- test that head sessions delete their vector data

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c1d48810832188d57d195b438446