### PR TITLE
fix React re-import for editor disabled test

### DIFF
--- a/test/editor-disabled.test.tsx
+++ b/test/editor-disabled.test.tsx
@@ -1,7 +1,5 @@
 // Tests run in the default Node environment; no DOM APIs are required.
 
-import React from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 import { test, jest } from '@jest/globals';
 import assert from 'node:assert';
 
@@ -13,6 +11,8 @@ test('export and generate buttons require target and lang', async () => {
   if (!global.TextDecoder) global.TextDecoder = TextDecoder;
 
   // initial render without target/lang -> buttons disabled
+  let React = (await import('react')).default;
+  let { renderToStaticMarkup } = await import('react-dom/server');
   let { default: Editor } = await import('../src/components/Editor');
   const initial = renderToStaticMarkup(<Editor />);
   assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Export \(compose demo\)<\/button>/);
@@ -20,6 +20,9 @@ test('export and generate buttons require target and lang', async () => {
   assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
 
   // render with target and lang preset -> buttons enabled
+  jest.resetModules();
+  React = (await import('react')).default;
+  ({ renderToStaticMarkup } = await import('react-dom/server'));
   const origUseState = React.useState;
   let calls = 0;
   jest.spyOn(React, 'useState').mockImplementation((init: any) => {
@@ -28,7 +31,6 @@ test('export and generate buttons require target and lang', async () => {
     if (calls === 4) return ['en', () => {}]; // lang
     return origUseState(init);
   });
-  jest.resetModules();
   ({ default: Editor } = await import('../src/components/Editor'));
   const withValues = renderToStaticMarkup(<Editor />);
   (React.useState as any).mockRestore();


### PR DESCRIPTION
## Summary
- re-import React and `react-dom/server` after `jest.resetModules`
- spy on reloaded React `useState` before re-importing Editor to avoid dispatcher mismatch

## Testing
- `npm test -- test/editor-disabled.test.tsx` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c1d6e71c8321928d0692459e8318