### PR TITLE
docs: describe VECTOR_DB and session limits

### DIFF
--- a/docs/head.md
+++ b/docs/head.md
@@ -3,7 +3,8 @@
 The `head` worker manages up to ten concurrent secretary sessions by default.
 You can override this limit by setting the `HEAD_MAX_SESSIONS` environment
 variable. Each session is isolated by `card_id` and stores its vectors under
-`/vector_db/qaadi_sec_<card_id>`.
+`$VECTOR_DB/qaadi_sec_<card_id>`. The `VECTOR_DB` environment variable defines
+the root directory for vector storage and defaults to `/vector_db`.
 
 ## API usage
 
@@ -24,13 +25,13 @@ The response returns the generated `session_id` (SHA256 of
 In a Node.js script:
 
 ```ts
-import { runHead } from '../src/lib/workers';
+import { runHead, cleanupHead } from '../src/lib/workers';
 
 const session = await runHead({ card_id: 'abc123', user: 'alice', nonce: '1' });
 console.log(session.session_id);
 
-// When finished, end the session and remove its vectors
-await endHead('abc123');
+// When finished, remove the session's vectors
+await cleanupHead('abc123');
 ```
 
 Remember to keep fewer than the configured maximum (default ten) sessions active

--- a/src/lib/workers/head.ts
+++ b/src/lib/workers/head.ts
@@ -3,6 +3,7 @@ import path from "path";
 import crypto from "crypto";
 
 const MAX_SESSIONS = Number(process.env.HEAD_MAX_SESSIONS) || 10;
+const VECTOR_DB = process.env.VECTOR_DB || "/vector_db";
 
 interface SessionInfo {
   session_id: string;
@@ -28,7 +29,7 @@ export async function runHead(opts: {
     throw new Error("too_many_sessions");
   }
 
-  const vectorPath = path.join("/vector_db", `qaadi_sec_${card_id}`);
+  const vectorPath = path.join(VECTOR_DB, `qaadi_sec_${card_id}`);
   await mkdir(vectorPath, { recursive: true });
   const session_id = sha256(card_id + user + nonce);
   const info = { session_id, vectorPath };

--- a/test/head-isolation.test.ts
+++ b/test/head-isolation.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@jest/globals';
 import {
   runHead,
-  endHead,
+  cleanupHead,
   resetHead,
   runResearchCenter,
   activeHeadSessions,
@@ -11,11 +11,13 @@ import path from 'node:path';
 import { tmpdir } from 'node:os';
 
 test('AT-1/AT-5 vector store isolation', async () => {
+  const vecRoot = await mkdtemp(path.join(tmpdir(), 'vector-'));
+  process.env.VECTOR_DB = vecRoot;
   resetHead();
   const s1 = await runHead({ card_id: 'a1', user: 'u', nonce: 'n1' });
   const s2 = await runHead({ card_id: 'a2', user: 'u', nonce: 'n1' });
-  const dir1 = path.join('/vector_db', 'qaadi_sec_a1');
-  const dir2 = path.join('/vector_db', 'qaadi_sec_a2');
+  const dir1 = path.join(vecRoot, 'qaadi_sec_a1');
+  const dir2 = path.join(vecRoot, 'qaadi_sec_a2');
   await stat(dir1);
   await stat(dir2);
   expect(dir1).not.toBe(dir2);
@@ -25,13 +27,16 @@ test('AT-1/AT-5 vector store isolation', async () => {
   }
   await expect(runHead({ card_id: 'a11', user: 'u', nonce: 'n1' })).rejects.toThrow();
   for (let i = 1; i <= 10; i++) {
-    await endHead(`a${i}`);
-    await expect(stat(path.join('/vector_db', `qaadi_sec_a${i}`))).rejects.toThrow();
+    await cleanupHead(`a${i}`);
+    await expect(stat(path.join(vecRoot, `qaadi_sec_a${i}`))).rejects.toThrow();
   }
   resetHead();
+  await rm(vecRoot, { recursive: true, force: true });
 });
 
 test('research center prevents data leakage between cards', async () => {
+  const vecRoot = await mkdtemp(path.join(tmpdir(), 'vector-'));
+  process.env.VECTOR_DB = vecRoot;
   resetHead();
   const dir = await mkdtemp(path.join(tmpdir(), 'qaadi-'));
   const plans = {
@@ -49,8 +54,9 @@ test('research center prevents data leakage between cards', async () => {
   expect(cmp).toContain('Alpha item');
   expect(cmp).toContain('Beta item');
   expect(activeHeadSessions()).toEqual([]);
-  await expect(stat(path.join('/vector_db', 'qaadi_sec_alpha'))).rejects.toThrow();
-  await expect(stat(path.join('/vector_db', 'qaadi_sec_beta'))).rejects.toThrow();
+  await expect(stat(path.join(vecRoot, 'qaadi_sec_alpha'))).rejects.toThrow();
+  await expect(stat(path.join(vecRoot, 'qaadi_sec_beta'))).rejects.toThrow();
   await rm(dir, { recursive: true, force: true });
+  await rm(vecRoot, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary
- document VECTOR_DB and HEAD_MAX_SESSIONS for head worker
- allow head worker to read VECTOR_DB env variable
- isolate head vectors in tests using temporary VECTOR_DB

## Testing
- `npm test -- test/head-isolation.test.ts` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a571bd6dbc8321a81d3e891b04f833