### PR TITLE
feat: support configurable vector db path

### DIFF
--- a/docs/head.md
+++ b/docs/head.md
@@ -3,7 +3,13 @@
 The `head` worker manages up to ten concurrent secretary sessions by default.
 You can override this limit by setting the `HEAD_MAX_SESSIONS` environment
 variable. Each session is isolated by `card_id` and stores its vectors under
-`/vector_db/qaadi_sec_<card_id>`.
+`$VECTOR_DB/qaadi_sec_<card_id>`. If `VECTOR_DB` is unset, the worker falls
+back to a `vector_db` directory inside the operating system's temporary
+directory.
+
+> **Vercel:** The deployment filesystem is read-only except for `/tmp`. Configure
+> the `VECTOR_DB` environment variable to a writable path such as
+> `/tmp/vector_db`.
 
 ## API usage
 

--- a/src/lib/workers/head.ts
+++ b/src/lib/workers/head.ts
@@ -1,8 +1,10 @@
 import { mkdir, rm } from "fs/promises";
 import path from "path";
 import crypto from "crypto";
+import { tmpdir } from "os";
 
 const MAX_SESSIONS = Number(process.env.HEAD_MAX_SESSIONS) || 10;
+const VECTOR_DB = process.env.VECTOR_DB ?? path.join(tmpdir(), "vector_db");
 
 interface SessionInfo {
   session_id: string;
@@ -28,7 +30,7 @@ export async function runHead(opts: {
     throw new Error("too_many_sessions");
   }
 
-  const vectorPath = path.join("/vector_db", `qaadi_sec_${card_id}`);
+  const vectorPath = path.join(VECTOR_DB, `qaadi_sec_${card_id}`);
   await mkdir(vectorPath, { recursive: true });
   const session_id = sha256(card_id + user + nonce);
   const info = { session_id, vectorPath };


### PR DESCRIPTION
## Summary
- allow head worker to store vectors under configurable VECTOR_DB path with tmpdir fallback
- document Vercel requirement to set VECTOR_DB to a writable path like /tmp/vector_db

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a571bc8c4c8321b2a62a2d9d08e24d