### PR TITLE
test: enable editor actions when required fields filled

### DIFF
--- a/test/editor-disabled.test.tsx
+++ b/test/editor-disabled.test.tsx
@@ -3,14 +3,14 @@
 import { test, jest } from '@jest/globals';
 import assert from 'node:assert';
 
-test('export and generate buttons require target and lang', async () => {
+test('export and generate buttons require api key, target, lang, and text', async () => {
   const { TextEncoder, TextDecoder } = await import('util');
   // @ts-ignore
   if (!global.TextEncoder) global.TextEncoder = TextEncoder;
   // @ts-ignore
   if (!global.TextDecoder) global.TextDecoder = TextDecoder;
 
-  // initial render without target/lang -> buttons disabled
+  // initial render without required fields -> buttons disabled
   let React = (await import('react')).default;
   let { renderToStaticMarkup } = await import('react-dom/server');
   let { default: Editor } = await import('../src/components/Editor');
@@ -19,7 +19,7 @@ test('export and generate buttons require target and lang', async () => {
   assert.match(initial, /<button class="btn btn-primary"[^>]*disabled[^>]*>Export ZIP<\/button>/);
   assert.match(initial, /<button class="btn"[^>]*disabled[^>]*>Generate<\/button>/);
 
-  // render with target and lang preset -> buttons enabled
+  // render with api key, target, lang, and text preset -> buttons enabled
   jest.resetModules();
   React = (await import('react')).default;
   ({ renderToStaticMarkup } = await import('react-dom/server'));
@@ -27,8 +27,10 @@ test('export and generate buttons require target and lang', async () => {
   let calls = 0;
   jest.spyOn(React, 'useState').mockImplementation((init: any) => {
     calls++;
+    if (calls === 1) return ['sk-abc', () => {}]; // openaiKey
     if (calls === 3) return ['revtex', () => {}]; // target
     if (calls === 4) return ['en', () => {}]; // lang
+    if (calls === 7) return ['sample text', () => {}]; // text
     return origUseState(init);
   });
   ({ default: Editor } = await import('../src/components/Editor'));


### PR DESCRIPTION
## Summary
- expand Editor test to mock api key and text along with target/lang
- ensure export and generate buttons are enabled when all required fields are populated

## Testing
- `npm test -- test/editor-disabled.test.tsx` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a618f5701483218e28f629d532a75b