### PR TITLE
refactor: make vector db root dynamic

### DIFF
--- a/docs/head.md
+++ b/docs/head.md
@@ -4,7 +4,8 @@ The `head` worker manages up to ten concurrent secretary sessions by default.
 You can override this limit by setting the `HEAD_MAX_SESSIONS` environment
 variable. Each session is isolated by `card_id` and stores its vectors under
 `$VECTOR_DB/qaadi_sec_<card_id>`. The `VECTOR_DB` environment variable defines
-the root directory for vector storage and defaults to `/vector_db`.
+the root directory for vector storage and defaults to `./vector_db` under the
+current working directory.
 
 ## API usage
 

--- a/src/lib/workers/head.ts
+++ b/src/lib/workers/head.ts
@@ -3,7 +3,10 @@ import path from "path";
 import crypto from "crypto";
 
 const MAX_SESSIONS = Number(process.env.HEAD_MAX_SESSIONS) || 10;
-const VECTOR_DB = process.env.VECTOR_DB || "/vector_db";
+
+export function getVectorDbRoot() {
+  return process.env.VECTOR_DB || path.join(process.cwd(), "vector_db");
+}
 
 interface SessionInfo {
   session_id: string;
@@ -29,7 +32,7 @@ export async function runHead(opts: {
     throw new Error("too_many_sessions");
   }
 
-  const vectorPath = path.join(VECTOR_DB, `qaadi_sec_${card_id}`);
+  const vectorPath = path.join(getVectorDbRoot(), `qaadi_sec_${card_id}`);
   await mkdir(vectorPath, { recursive: true });
   const session_id = sha256(card_id + user + nonce);
   const info = { session_id, vectorPath };

--- a/src/lib/workers/index.ts
+++ b/src/lib/workers/index.ts
@@ -11,5 +11,6 @@ export {
   resetHead,
   activeHeadSessions,
   exportHead,
+  getVectorDbRoot,
 } from "./head";
 export { runResearchCenter } from "./researchCenter";


### PR DESCRIPTION
## Summary
- add `getVectorDbRoot` helper to dynamically resolve vector DB path
- update head worker to create session directories with `getVectorDbRoot`
- document new default vector DB location and re-export helper

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a618ebd1248321be316756949b5a6d