### PR TITLE
Refactor secretary form for updated research workflow

### DIFF
--- a/src/components/Secretary.tsx
+++ b/src/components/Secretary.tsx
@@ -3,16 +3,13 @@
 import { useState, FormEvent } from "react";
 
 export default function Secretary() {
-  const [summary, setSummary] = useState("");
+  const [abstract, setAbstract] = useState("");
   const [keywords, setKeywords] = useState("");
-  const [tokens, setTokens] = useState("");
-  const [boundary, setBoundary] = useState("");
+  const [nomenclature, setNomenclature] = useState("");
+  const [boundaryConditions, setBoundaryConditions] = useState("");
   const [coreEquations, setCoreEquations] = useState("");
   const [dimensional, setDimensional] = useState("");
-  const [postAnalysis, setPostAnalysis] = useState("");
-  const [risks, setRisks] = useState("");
-  const [predictions, setPredictions] = useState("");
-  const [testability, setTestability] = useState("");
+  const [limitationsRisks, setLimitationsRisks] = useState("");
   const [references, setReferences] = useState("");
   const [overflow, setOverflow] = useState("");
   const [identity, setIdentity] = useState("");
@@ -20,39 +17,30 @@ export default function Secretary() {
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     const data = {
-      summary,
+      abstract,
       keywords: keywords
         .split(",")
         .map((k) => k.trim())
         .filter(Boolean),
-      tokens: tokens
-        .split(",")
-        .map((t) => t.trim())
+      nomenclature: nomenclature
+        .split("\n")
+        .map((n) => n.trim())
         .filter(Boolean),
-      boundary: boundary
-        .split(",")
+      boundary_conditions: boundaryConditions
+        .split("\n")
         .map((b) => b.trim())
         .filter(Boolean),
       core_equations: coreEquations
         .split("\n")
         .map((e) => e.trim())
         .filter(Boolean),
-      dimensional,
-      post_analysis: postAnalysis,
-      risks: risks
-        .split(",")
-        .map((r) => r.trim())
-        .filter(Boolean),
-      predictions: predictions
-        .split(",")
-        .map((p) => p.trim())
-        .filter(Boolean),
-      testability,
-      references: references
+      dimensional_analysis: dimensional,
+      limitations_risks: limitationsRisks,
+      preliminary_references: references
         .split("\n")
         .map((r) => r.trim())
         .filter(Boolean),
-      overflow: overflow
+      overflow_log: overflow
         .split(",")
         .map((o) => o.trim())
         .filter(Boolean),
@@ -66,10 +54,10 @@ export default function Secretary() {
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
-        <label className="block font-semibold">Summary</label>
+        <label className="block font-semibold">Abstract (150–300 words)</label>
         <textarea
-          value={summary}
-          onChange={(e) => setSummary(e.target.value)}
+          value={abstract}
+          onChange={(e) => setAbstract(e.target.value)}
           className="w-full border p-2"
         />
       </div>
@@ -83,25 +71,29 @@ export default function Secretary() {
         />
       </div>
       <div>
-        <label className="block font-semibold">Tokens (symbol=definition, comma separated)</label>
-        <input
-          type="text"
-          value={tokens}
-          onChange={(e) => setTokens(e.target.value)}
+        <label className="block font-semibold">
+          Nomenclature (symbol | unit | definition per line)
+        </label>
+        <textarea
+          value={nomenclature}
+          onChange={(e) => setNomenclature(e.target.value)}
           className="w-full border p-2"
         />
       </div>
       <div>
-        <label className="block font-semibold">Boundary conditions (comma separated)</label>
-        <input
-          type="text"
-          value={boundary}
-          onChange={(e) => setBoundary(e.target.value)}
+        <label className="block font-semibold">
+          Boundary Conditions (type: expression per line)
+        </label>
+        <textarea
+          value={boundaryConditions}
+          onChange={(e) => setBoundaryConditions(e.target.value)}
           className="w-full border p-2"
         />
       </div>
       <div>
-        <label className="block font-semibold">Core Equations (one per line)</label>
+        <label className="block font-semibold">
+          Core Equations (LaTeX, one per line)
+        </label>
         <textarea
           value={coreEquations}
           onChange={(e) => setCoreEquations(e.target.value)}
@@ -117,41 +109,17 @@ export default function Secretary() {
         />
       </div>
       <div>
-        <label className="block font-semibold">Post-analysis</label>
+        <label className="block font-semibold">Limitations &amp; Risks</label>
         <textarea
-          value={postAnalysis}
-          onChange={(e) => setPostAnalysis(e.target.value)}
+          value={limitationsRisks}
+          onChange={(e) => setLimitationsRisks(e.target.value)}
           className="w-full border p-2"
         />
       </div>
       <div>
-        <label className="block font-semibold">Risks (comma separated)</label>
-        <input
-          type="text"
-          value={risks}
-          onChange={(e) => setRisks(e.target.value)}
-          className="w-full border p-2"
-        />
-      </div>
-      <div>
-        <label className="block font-semibold">Predictions (comma separated)</label>
-        <input
-          type="text"
-          value={predictions}
-          onChange={(e) => setPredictions(e.target.value)}
-          className="w-full border p-2"
-        />
-      </div>
-      <div>
-        <label className="block font-semibold">Testability</label>
-        <textarea
-          value={testability}
-          onChange={(e) => setTestability(e.target.value)}
-          className="w-full border p-2"
-        />
-      </div>
-      <div>
-        <label className="block font-semibold">References (one per line)</label>
+        <label className="block font-semibold">
+          Preliminary References (one per line)
+        </label>
         <textarea
           value={references}
           onChange={(e) => setReferences(e.target.value)}
@@ -159,7 +127,7 @@ export default function Secretary() {
         />
       </div>
       <div>
-        <label className="block font-semibold">Overflow log (comma separated)</label>
+        <label className="block font-semibold">Overflow Log (comma separated)</label>
         <input
           type="text"
           value={overflow}

--- a/src/lib/workers/secretary.ts
+++ b/src/lib/workers/secretary.ts
@@ -9,18 +9,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, "../../../");
 
 export interface SecretaryData {
-  summary: string;
+  abstract: string;
   keywords: string[];
-  tokens: string[];
-  boundary: string[];
+  nomenclature: string[];
+  boundary_conditions: string[];
   core_equations: string[];
-  dimensional: string;
-  post_analysis: string;
-  risks: string[];
-  predictions: string[];
-  testability: string;
-  references: string[];
-  overflow?: string[];
+  dimensional_analysis: string;
+  limitations_risks: string;
+  preliminary_references: string[];
+  overflow_log?: string[];
 }
 
 /**
@@ -29,23 +26,20 @@ export interface SecretaryData {
  * function falls back to interactive prompts on the command line.
  */
 export async function runSecretary(data?: Partial<SecretaryData>) {
-  let summary: string;
+  let abstract: string;
   let keywords: string[];
-  let tokens: string[];
-  let boundary: string[];
+  let nomenclature: string[];
+  let boundary_conditions: string[];
   let core_equations: string[];
-  let dimensional: string;
-  let post_analysis: string;
-  let risks: string[];
-  let predictions: string[];
-  let testability: string;
-  let references: string[];
-  let overflow: string[];
+  let dimensional_analysis: string;
+  let limitations_risks: string;
+  let preliminary_references: string[];
+  let overflow_log: string[];
 
   if (!data) {
     const rl = createInterface({ input, output });
     try {
-      summary = await rl.question("Summary: ");
+      abstract = await rl.question("Abstract: ");
       const keyInput = await rl.question(
         "Keywords (comma separated): "
       );
@@ -53,17 +47,17 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
         .split(",")
         .map((k) => k.trim())
         .filter(Boolean);
-      const tokInput = await rl.question(
-        "Tokens and definitions (symbol=definition, comma separated): "
+      const nomInput = await rl.question(
+        "Nomenclature (symbol|unit|definition, comma separated): "
       );
-      tokens = tokInput
+      nomenclature = nomInput
         .split(",")
-        .map((t) => t.trim())
+        .map((n) => n.trim())
         .filter(Boolean);
       const boundInput = await rl.question(
         "Boundary conditions (comma separated): "
       );
-      boundary = boundInput
+      boundary_conditions = boundInput
         .split(",")
         .map((b) => b.trim())
         .filter(Boolean);
@@ -74,30 +68,19 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
         .split(",")
         .map((e) => e.trim())
         .filter(Boolean);
-      dimensional = await rl.question("Dimensional analysis: ");
-      post_analysis = await rl.question("Post-analysis: ");
-      const riskInput = await rl.question("Risks (comma separated): ");
-      risks = riskInput
-        .split(",")
-        .map((r) => r.trim())
-        .filter(Boolean);
-      const predInput = await rl.question("Predictions (comma separated): ");
-      predictions = predInput
-        .split(",")
-        .map((p) => p.trim())
-        .filter(Boolean);
-      testability = await rl.question("Testability: ");
+      dimensional_analysis = await rl.question("Dimensional analysis: ");
+      limitations_risks = await rl.question("Limitations & Risks: ");
       const refInput = await rl.question(
-        "References (comma separated): "
+        "Preliminary references (comma separated): "
       );
-      references = refInput
+      preliminary_references = refInput
         .split(",")
         .map((r) => r.trim())
         .filter(Boolean);
       const overflowInput = await rl.question(
         "Overflow log (comma separated, optional): "
       );
-      overflow = overflowInput
+      overflow_log = overflowInput
         .split(",")
         .map((o) => o.trim())
         .filter(Boolean);
@@ -106,33 +89,27 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
     }
   } else {
     ({
-      summary = "",
+      abstract = "",
       keywords = [],
-      tokens = [],
-      boundary = [],
+      nomenclature = [],
+      boundary_conditions = [],
       core_equations = [],
-      dimensional = "",
-      post_analysis = "",
-      risks = [],
-      predictions = [],
-      testability = "",
-      references = [],
-      overflow = [],
+      dimensional_analysis = "",
+      limitations_risks = "",
+      preliminary_references = [],
+      overflow_log = [],
     } = data);
   }
 
   const identityInput = [
-    summary,
+    abstract,
     keywords.join(","),
-    tokens.join(","),
-    boundary.join(","),
+    nomenclature.join(","),
+    boundary_conditions.join(","),
     core_equations.join(","),
-    dimensional,
-    post_analysis,
-    risks.join(","),
-    predictions.join(","),
-    testability,
-    references.join(","),
+    dimensional_analysis,
+    limitations_risks,
+    preliminary_references.join(","),
   ].join("|");
   const identity = createHash("sha256").update(identityInput).digest("hex").slice(0, 8);
 
@@ -143,14 +120,13 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
   console.log("Fingerprint:", fingerprint);
 
   const fields = {
-    summary,
+    abstract,
     keywords,
-    tokens,
-    boundary,
-    post_analysis,
-    risks,
-    predictions,
-    testability,
+    nomenclature,
+    boundary_conditions,
+    dimensional_analysis,
+    limitations_risks,
+    preliminary_references,
     identity,
   };
   const missing = Object.entries(fields)
@@ -176,41 +152,34 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
     "## Identity",
     identity,
     "",
-    "## Summary",
-    summary,
+    "## Abstract",
+    abstract,
     "",
     "## Keywords",
     ...keywords.map((k) => `- ${k}`),
     "",
-    "## Tokens and Definitions",
-    ...tokens.map((t) => `- ${t}`),
+    "## Nomenclature",
+    ...nomenclature.map((n) => `- ${n}`),
     "",
     "## Core Equations",
     ...core_equations.map((e) => `- ${e}`),
     "",
     "## Boundary Conditions",
-    ...boundary.map((b) => `- ${b}`),
+    ...boundary_conditions.map((b) => `- ${b}`),
     "",
     "## Dimensional Analysis",
-    dimensional,
+    dimensional_analysis,
     "",
-    "## Post-Analysis",
-    post_analysis,
+    "## Limitations & Risks",
+    limitations_risks,
     "",
-    "## Risks",
-    ...risks.map((r) => `- ${r}`),
-    "",
-    "## Predictions",
-    ...predictions.map((p) => `- ${p}`),
-    "",
-    "## Testability",
-    testability,
-    "",
-    "## References",
-    ...references.map((r) => `- ${r}`),
+    "## Preliminary References",
+    ...preliminary_references.map((r) => `- ${r}`),
     "",
     "## Overflow Log",
-    ...(overflow.length > 0 ? overflow.map((o) => `- ${o}`) : ["- none"]),
+    ...(overflow_log.length > 0
+      ? overflow_log.map((o) => `- ${o}`)
+      : ["- none"]),
     "",
   ].join("\n");
 


### PR DESCRIPTION
## Summary
- revamp Secretary component with fields for abstract, keywords, nomenclature, boundary conditions, core equations, dimensional analysis, limitations & risks, preliminary references, and overflow log
- remove obsolete post-analysis, predictions, and testability inputs
- update secretary worker to process new field structure and generate markdown accordingly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a64e45e418832198f9b38fa9788b7d