### PR TITLE
Include overflow in secretary gate

### DIFF
--- a/src/lib/workflow/gates.ts
+++ b/src/lib/workflow/gates.ts
@@ -7,6 +7,7 @@ export interface SecretaryReport {
   risks?: string[];
   predictions?: string[];
   testability?: string;
+  overflow?: string[];
   identity?: string;
 }
 
@@ -30,6 +31,7 @@ const REQUIRED_FIELDS: FieldKey[] = [
   "risks",
   "predictions",
   "testability",
+  "overflow",
   "identity",
 ];
 
@@ -46,6 +48,7 @@ export function runGates(data: { secretary?: { audit?: SecretaryReport } }): Gat
     risks: 0,
     predictions: 0,
     testability: 0,
+    overflow: 0,
     identity: 0,
   };
 

--- a/test/gates.test.ts
+++ b/test/gates.test.ts
@@ -9,7 +9,7 @@ test('runGates detects multiple missing fields', () => {
     identity: '',
   };
   const result = runGates({ secretary: { audit } });
-  assert.strictEqual(result.ready_percent, 22);
+  assert.strictEqual(result.ready_percent, 20);
   const expectedMissing: FieldKey[] = [
     'summary',
     'boundary',
@@ -17,6 +17,7 @@ test('runGates detects multiple missing fields', () => {
     'risks',
     'predictions',
     'testability',
+    'overflow',
     'identity',
   ];
   assert.deepStrictEqual(result.missing, expectedMissing);
@@ -29,6 +30,7 @@ test('runGates detects multiple missing fields', () => {
     risks: 0,
     predictions: 0,
     testability: 0,
+    overflow: 0,
     identity: 0,
   });
 });
@@ -43,6 +45,7 @@ test('runGates passes when all required fields are present', () => {
     risks: ['oversimplification'],
     predictions: ['growth'],
     testability: 'lab',
+    overflow: ['note'],
     identity: 'source',
   };
   const result = runGates({ secretary: { audit } });
@@ -57,6 +60,7 @@ test('runGates passes when all required fields are present', () => {
     risks: 1,
     predictions: 1,
     testability: 1,
+    overflow: 1,
     identity: 1,
   });
 });

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -96,6 +96,7 @@ test('runGates requires identity among fields', () => {
     risks: ['r'],
     predictions: ['pr'],
     testability: 'tst',
+    overflow: ['o'],
     identity: 'abcd1234',
   };
   const result = runGates({ secretary: { audit: report } });


### PR DESCRIPTION
## Summary
- track overflow log as a required secretary field
- update gates and tests for nine sections plus identity

## Testing
- `npm test` *(fails: jest not found; npm install forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a64e486d948321b060c7bd3e12049e