### PR TITLE
Update secretary report schema

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -242,14 +242,16 @@ export default function Editor() {
     try {
       if (!target || !lang) throw new Error("missing_target_lang");
       const secFields: SecretaryReport = {
-        summary: "demo summary",
+        abstract: "demo abstract",
         keywords: ["demo"],
-        tokens: ["token"],
-        boundary: ["demo"],
-        post_analysis: "demo",
-        risks: ["demo"],
-        predictions: ["demo"],
-        testability: "demo"
+        nomenclature: ["demo term"],
+        core_equations: ["E=mc^2"],
+        boundary_conditions: ["demo"],
+        dimensional_analysis: "demo",
+        limitations_risks: "demo",
+        preliminary_references: ["demo"],
+        overflow_log: ["demo"],
+        identity: "demo"
       };
       const gate = runGates({ secretary: { audit: secFields } });
       const res = await fetch("/api/export", {

--- a/src/lib/workflow/gates.ts
+++ b/src/lib/workflow/gates.ts
@@ -1,13 +1,13 @@
 export interface SecretaryReport {
-  summary?: string;
+  abstract?: string;
   keywords?: string[];
-  tokens?: string[];
-  boundary?: string[];
-  post_analysis?: string;
-  risks?: string[];
-  predictions?: string[];
-  testability?: string;
-  overflow?: string[];
+  nomenclature?: string[];
+  core_equations?: string[];
+  boundary_conditions?: string[];
+  dimensional_analysis?: string;
+  limitations_risks?: string;
+  preliminary_references?: string[];
+  overflow_log?: string[];
   identity?: string;
 }
 
@@ -23,15 +23,15 @@ export interface GateResult {
 // Required fields for a complete secretary report
 // These map directly to sections in templates/secretary.md
 const REQUIRED_FIELDS: FieldKey[] = [
-  "summary",
+  "abstract",
   "keywords",
-  "tokens",
-  "boundary",
-  "post_analysis",
-  "risks",
-  "predictions",
-  "testability",
-  "overflow",
+  "nomenclature",
+  "core_equations",
+  "boundary_conditions",
+  "dimensional_analysis",
+  "limitations_risks",
+  "preliminary_references",
+  "overflow_log",
   "identity",
 ];
 
@@ -40,15 +40,15 @@ export function runGates(data: { secretary?: { audit?: SecretaryReport } }): Gat
   const report = data.secretary?.audit;
   const missing: FieldKey[] = [];
   const fields: Record<FieldKey, FieldScore> = {
-    summary: 0,
+    abstract: 0,
     keywords: 0,
-    tokens: 0,
-    boundary: 0,
-    post_analysis: 0,
-    risks: 0,
-    predictions: 0,
-    testability: 0,
-    overflow: 0,
+    nomenclature: 0,
+    core_equations: 0,
+    boundary_conditions: 0,
+    dimensional_analysis: 0,
+    limitations_risks: 0,
+    preliminary_references: 0,
+    overflow_log: 0,
     identity: 0,
   };
 

--- a/test/gates.test.ts
+++ b/test/gates.test.ts
@@ -5,62 +5,62 @@ import { runGates, type SecretaryReport, type FieldKey } from '../src/lib/workfl
 test('runGates detects multiple missing fields', () => {
   const audit: SecretaryReport = {
     keywords: ['physics'],
-    tokens: ['c: light'],
     identity: '',
   };
   const result = runGates({ secretary: { audit } });
-  assert.strictEqual(result.ready_percent, 20);
+  assert.strictEqual(result.ready_percent, 10);
   const expectedMissing: FieldKey[] = [
-    'summary',
-    'boundary',
-    'post_analysis',
-    'risks',
-    'predictions',
-    'testability',
-    'overflow',
+    'abstract',
+    'nomenclature',
+    'core_equations',
+    'boundary_conditions',
+    'dimensional_analysis',
+    'limitations_risks',
+    'preliminary_references',
+    'overflow_log',
     'identity',
   ];
   assert.deepStrictEqual(result.missing, expectedMissing);
   assert.deepStrictEqual(result.fields, {
-    summary: 0,
+    abstract: 0,
     keywords: 1,
-    tokens: 1,
-    boundary: 0,
-    post_analysis: 0,
-    risks: 0,
-    predictions: 0,
-    testability: 0,
-    overflow: 0,
+    nomenclature: 0,
+    core_equations: 0,
+    boundary_conditions: 0,
+    dimensional_analysis: 0,
+    limitations_risks: 0,
+    preliminary_references: 0,
+    overflow_log: 0,
     identity: 0,
   });
 });
 
 test('runGates passes when all required fields are present', () => {
   const audit: SecretaryReport = {
-    summary: 'Overview',
+    abstract: 'Overview',
     keywords: ['physics'],
-    tokens: ['c: light'],
-    boundary: ['t=0'],
-    post_analysis: 'dimensionless',
-    risks: ['oversimplification'],
-    predictions: ['growth'],
-    testability: 'lab',
-    overflow: ['note'],
+    nomenclature: ['m|kg|mass'],
+    core_equations: ['E=mc^2'],
+    boundary_conditions: ['t=0'],
+    dimensional_analysis: 'dimensionless',
+    limitations_risks: 'oversimplification',
+    preliminary_references: ['Doe 2020'],
+    overflow_log: ['note'],
     identity: 'source',
   };
   const result = runGates({ secretary: { audit } });
   assert.strictEqual(result.ready_percent, 100);
   assert.deepStrictEqual(result.missing, []);
   assert.deepStrictEqual(result.fields, {
-    summary: 1,
+    abstract: 1,
     keywords: 1,
-    tokens: 1,
-    boundary: 1,
-    post_analysis: 1,
-    risks: 1,
-    predictions: 1,
-    testability: 1,
-    overflow: 1,
+    nomenclature: 1,
+    core_equations: 1,
+    boundary_conditions: 1,
+    dimensional_analysis: 1,
+    limitations_risks: 1,
+    preliminary_references: 1,
+    overflow_log: 1,
     identity: 1,
   });
 });

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -6,17 +6,17 @@ import { tmpdir } from 'node:os';
 import { runSecretary, runResearchSecretary } from '../src/lib/workers/index.ts';
 import { runGates } from '../src/lib/workflow/gates.ts';
 
-// Build sample data using nine secretary fields
+// Build sample data using revised secretary fields
 const sampleSecretary = {
-  summary: 'Project overview',
+  abstract: 'Project overview',
   keywords: ['analysis', 'physics'],
-  tokens: ['c: speed of light', 'm: mass'],
-  boundary: ['t=0', 'x->∞'],
-  post_analysis: 'post review',
-  risks: ['oversimplification'],
-  predictions: ['growth'],
-  testability: 'lab experiments',
-  references: ['Doe 2020'],
+  nomenclature: ['c|m/s|speed of light', 'm|kg|mass'],
+  boundary_conditions: ['t=0', 'x->∞'],
+  core_equations: ['E=mc^2'],
+  dimensional_analysis: 'dimensionless',
+  limitations_risks: 'oversimplification',
+  preliminary_references: ['Doe 2020'],
+  overflow_log: [],
 };
 
 const samplePlan = [
@@ -36,30 +36,29 @@ test('runSecretary generates a complete secretary.md', async () => {
     assert.match(fileContent, /Fingerprint: qaadi-live\/0.1.0\/\d{4}-\d{2}-\d{2}\/[0-9a-f]{8}/);
     assert.match(fileContent, /Ready%: 100/);
     assert.match(fileContent, /## Identity\n[0-9a-f]{8}/);
-    assert.match(fileContent, /## Summary\nProject overview/);
+    assert.match(fileContent, /## Abstract\nProject overview/);
     assert.match(
       fileContent,
       /## Keywords\n- analysis\n- physics/
     );
     assert.match(
       fileContent,
-      /## Tokens and Definitions\n- c: speed of light\n- m: mass/
+      /## Nomenclature\n- c\|m\/s\|speed of light\n- m\|kg\|mass/
+    );
+    assert.match(
+      fileContent,
+      /## Core Equations\n- E=mc\^2/
     );
     assert.match(
       fileContent,
       /## Boundary Conditions\n- t=0\n- x->∞/
     );
-    assert.match(fileContent, /## Post-Analysis\npost review/);
+    assert.match(fileContent, /## Dimensional Analysis\ndimensionless/);
     assert.match(
       fileContent,
-      /## Risks\n- oversimplification/
+      /## Limitations & Risks\noversimplification/
     );
-    assert.match(
-      fileContent,
-      /## Predictions\n- growth/
-    );
-    assert.match(fileContent, /## Testability\nlab experiments/);
-    assert.match(fileContent, /## References\n- Doe 2020/);
+    assert.match(fileContent, /## Preliminary References\n- Doe 2020/);
     assert.match(fileContent, /## Overflow Log\n- none/);
   } finally {
     process.chdir(prev);
@@ -71,9 +70,9 @@ test('runSecretary calculates readiness based on missing fields', async () => {
   const prev = process.cwd();
   process.chdir(dir);
   try {
-    const partial = { ...sampleSecretary, summary: '' };
+    const partial = { ...sampleSecretary, abstract: '' };
     const content = await runSecretary(partial);
-    assert.match(content, /Ready%: 89/);
+    assert.match(content, /Ready%: 88/);
   } finally {
     process.chdir(prev);
   }
@@ -81,21 +80,21 @@ test('runSecretary calculates readiness based on missing fields', async () => {
 
 test('runGates requires identity among fields', () => {
   const report = {
-    summary: 's',
+    abstract: 's',
     keywords: ['k'],
-    tokens: ['t'],
-    boundary: ['b'],
-    post_analysis: 'p',
-    risks: ['r'],
-    predictions: ['pr'],
-    testability: 'tst',
-    overflow: ['o'],
+    nomenclature: ['n'],
+    core_equations: ['e'],
+    boundary_conditions: ['b'],
+    dimensional_analysis: 'd',
+    limitations_risks: 'r',
+    preliminary_references: ['p'],
+    overflow_log: ['o'],
     identity: 'abcd1234',
   };
   const result = runGates({ secretary: { audit: report } });
   assert.strictEqual(result.ready_percent, 100);
   const missing = runGates({ secretary: { audit: { ...report, identity: '' } } });
-  assert.strictEqual(missing.ready_percent, 89);
+  assert.strictEqual(missing.ready_percent, 90);
   assert.ok(missing.missing.includes('identity'));
 });
 
@@ -104,11 +103,11 @@ test('runSecretary handles malformed nomenclature rows', async () => {
   const prev = process.cwd();
   process.chdir(dir);
   try {
-    const malformed = { ...sampleSecretary, tokens: ['bad row', 'm: mass'] };
+    const malformed = { ...sampleSecretary, nomenclature: ['bad row', 'm|kg|mass'] };
     const content = await runSecretary(malformed);
     assert.match(
       content,
-      /## Tokens and Definitions\n- bad row\n- m: mass/
+      /## Nomenclature\n- bad row\n- m\|kg\|mass/
     );
     assert.match(content, /Ready%: 100/);
   } finally {
@@ -121,10 +120,10 @@ test('runSecretary outputs empty references section when none provided', async (
   const prev = process.cwd();
   process.chdir(dir);
   try {
-    const noRefs = { ...sampleSecretary, references: [] };
+    const noRefs = { ...sampleSecretary, preliminary_references: [] };
     const content = await runSecretary(noRefs);
     assert.match(content, /Ready%: 100/);
-    assert.match(content, /## References\n\n## Overflow Log\n- none/);
+    assert.match(content, /## Preliminary References\n\n## Overflow Log\n- none/);
   } finally {
     process.chdir(prev);
   }


### PR DESCRIPTION
## Summary
- revise secretary gating to use abstract, nomenclature, core equations, boundary conditions, dimensional analysis, limitations, references, overflow log, and identity
- adjust editor export to send new secretary report fields
- update tests for new secretary report structure

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a65ce872448321930befd160986018