### PR TITLE
Include core_equations in secretary readiness calculation

### DIFF
--- a/src/lib/workers/secretary.ts
+++ b/src/lib/workers/secretary.ts
@@ -124,6 +124,7 @@ export async function runSecretary(data?: Partial<SecretaryData>) {
     keywords,
     nomenclature,
     boundary_conditions,
+    core_equations,
     dimensional_analysis,
     limitations_risks,
     preliminary_references,

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -72,7 +72,7 @@ test('runSecretary calculates readiness based on missing fields', async () => {
   try {
     const partial = { ...sampleSecretary, abstract: '' };
     const content = await runSecretary(partial);
-    assert.match(content, /Ready%: 88/);
+    assert.match(content, /Ready%: 89/);
   } finally {
     process.chdir(prev);
   }
@@ -122,7 +122,7 @@ test('runSecretary outputs empty references section when none provided', async (
   try {
     const noRefs = { ...sampleSecretary, preliminary_references: [] };
     const content = await runSecretary(noRefs);
-    assert.match(content, /Ready%: 100/);
+    assert.match(content, /Ready%: 89/);
     assert.match(content, /## Preliminary References\n\n## Overflow Log\n- none/);
   } finally {
     process.chdir(prev);


### PR DESCRIPTION
## Summary
- validate `core_equations` alongside other secretary fields
- adjust readiness percentage expectations in secretary workflow tests

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a67a54d40c8321b7cbf63fae515140