### PR TITLE
Include overflow log in identity hash

### DIFF
--- a/src/lib/workers/secretary.ts
+++ b/src/lib/workers/secretary.ts
@@ -109,6 +109,7 @@ export async function runSecretary(
     dimensional_analysis,
     limitations_risks,
     preliminary_references.join(","),
+    overflow_log.join(","),
   ].join("|");
   const identity = createHash("sha256").update(identityInput).digest("hex").slice(0, 8);
 

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -36,9 +36,13 @@ test('runSecretary generates a complete secretary.md', async () => {
     const filePath = path.join(dir, 'paper', 'secretary.md');
     const fileContent = await readFile(filePath, 'utf8');
     assert.strictEqual(fileContent, content);
-    assert.match(fileContent, /Fingerprint: qaadi-live\/0.1.0\/\d{4}-\d{2}-\d{2}\/[0-9a-f]{8}/);
+    const expectedId = 'd6ed8e3e';
+    assert.match(
+      fileContent,
+      new RegExp(`Fingerprint: qaadi-live/0\\.1\\.0/\\d{4}-\\d{2}-\\d{2}/${expectedId}`)
+    );
     assert.match(fileContent, /Ready%: 100/);
-    assert.match(fileContent, /## Identity\n[0-9a-f]{8}/);
+    assert.match(fileContent, new RegExp(`## Identity\\n${expectedId}`));
     assert.match(fileContent, /## Abstract\nProject overview/);
     assert.match(
       fileContent,


### PR DESCRIPTION
## Summary
- factor the secretary overflow log into the identity hash
- update secretary workflow test to expect the new identity value

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d469647083218f9e8715fc6269e9