### PR TITLE
Treat empty overflow logs as present

### DIFF
--- a/src/lib/workers/secretary.ts
+++ b/src/lib/workers/secretary.ts
@@ -100,6 +100,10 @@ export async function runSecretary(
     } = data);
   }
 
+  if (!overflow_log || overflow_log.length === 0) {
+    overflow_log = ["none"];
+  }
+
   const identityInput = [
     abstract,
     keywords.join(","),

--- a/src/lib/workflow/gates.ts
+++ b/src/lib/workflow/gates.ts
@@ -62,7 +62,7 @@ export function runGates(data: { secretary?: { audit?: SecretaryReport } }): Gat
       value === undefined ||
       value === null ||
       (typeof value === "string" && !value.trim()) ||
-      (Array.isArray(value) && value.length === 0);
+      (Array.isArray(value) && value.length === 0 && field !== "overflow_log");
     fields[field] = isMissing ? 0 : 1;
     if (isMissing) missing.push(field);
   }

--- a/test/gates.test.ts
+++ b/test/gates.test.ts
@@ -45,7 +45,7 @@ test('runGates passes when all required fields are present', () => {
     dimensional_analysis: 'dimensionless',
     limitations_risks: 'oversimplification',
     preliminary_references: ['Doe 2020'],
-    overflow_log: ['note'],
+    overflow_log: [],
     identity: 'source',
   };
   const result = runGates({ secretary: { audit } });

--- a/test/secretary-workflow.test.ts
+++ b/test/secretary-workflow.test.ts
@@ -92,7 +92,7 @@ test('runGates requires identity among fields', () => {
     dimensional_analysis: 'd',
     limitations_risks: 'r',
     preliminary_references: ['p'],
-    overflow_log: ['o'],
+    overflow_log: [],
     identity: 'abcd1234',
   };
   const result = runGates({ secretary: { audit: report } });


### PR DESCRIPTION
## Summary
- Default secretary overflow logs to `"none"` when no entries exist
- Consider an empty overflow log as present in workflow gate checks
- Adjust gate tests for new readiness rules

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d46777988321a3a85846c28a0f55